### PR TITLE
fix(media): pin qbittorrent image to :release tag

### DIFF
--- a/argocd/base/qbittorrent/deployment.yaml
+++ b/argocd/base/qbittorrent/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: qbittorrent
-          image: ghcr.io/hotio/qbittorrent:latest
+          image: ghcr.io/hotio/qbittorrent:release
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

- Remplace le tag `:latest` par `:release` sur l'image qBittorrent pour des déploiements reproductibles
- Aligne avec les autres apps media (prowlarr, sonarr, radarr) qui utilisent déjà `:release`

## Test plan

- [ ] Vérifier que le pod qBittorrent redémarre correctement avec le tag `:release`