### PR TITLE
fix(talos): corriger le bootstrap dev Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,12 @@ ifeq ($(ENV),dev)
 	@echo "==> Creation du cluster dev (Docker)..."
 	talosctl cluster create docker \
 		--name $(CLUSTER_NAME) \
-		--workers 1
+		--workers 2 \
+		--kubernetes-version v1.35.0 \
+		--image ghcr.io/siderolabs/talos:v1.12.0 \
+		--memory-controlplanes 4096 \
+		--memory-workers 4096 \
+		--config-patch @$(TALOS_DIR)/patch.yaml
 	@echo "==> Recuperation du kubeconfig..."
 	@API_PORT=$$(docker port $(CLUSTER_NAME)-controlplane-1 6443/tcp | cut -d: -f2) && \
 		talosctl kubeconfig $(KUBECONFIG) --nodes 10.5.0.2 --force && \
@@ -45,14 +50,22 @@ else
 endif
 
 # ============================================================
-# Cilium (CNI) - prod uniquement
+# Cilium (CNI)
 # ============================================================
 
-cilium: ## Installer Cilium via Helm (prod uniquement)
+cilium: ## Installer Cilium via Helm (remplace flannel en dev)
 	@echo "==> Installation de Cilium..."
 	helm repo add cilium https://helm.cilium.io/ 2>/dev/null || true
 	helm repo update cilium
-	helm install cilium cilium/cilium \
+ifeq ($(ENV),dev)
+	@echo "==> Suppression de flannel (CNI par defaut)..."
+	-kubectl --kubeconfig $(KUBECONFIG) delete daemonset -n kube-system kube-flannel 2>/dev/null
+	-kubectl --kubeconfig $(KUBECONFIG) delete configmap -n kube-system kube-flannel-cfg 2>/dev/null
+	-kubectl --kubeconfig $(KUBECONFIG) delete serviceaccount -n kube-system flannel 2>/dev/null
+	-kubectl --kubeconfig $(KUBECONFIG) delete clusterrole flannel 2>/dev/null
+	-kubectl --kubeconfig $(KUBECONFIG) delete clusterrolebinding flannel 2>/dev/null
+endif
+	helm upgrade --install cilium cilium/cilium \
 		--namespace kube-system \
 		--kubeconfig $(KUBECONFIG) \
 		--version 1.17.1 \

--- a/talos/dev/patch.yaml
+++ b/talos/dev/patch.yaml
@@ -1,0 +1,12 @@
+machine:
+  network:
+    nameservers:
+      - 1.1.1.1
+      - 8.8.8.8
+  kernel:
+    modules:
+      - name: nfs
+      - name: nfsd
+  time:
+    servers:
+      - time.cloudflare.com

--- a/talos/dev/talconfig.yaml
+++ b/talos/dev/talconfig.yaml
@@ -6,8 +6,8 @@ endpoint: https://10.5.0.2:6443
 
 allowSchedulingOnControlPlanes: true
 
-cniConfig:
-  name: none
+# CNI: flannel au boot (remplace par Cilium via make cilium)
+# En prod, cniConfig: none car Cilium est installe manuellement avant le bootstrap
 
 nodes:
   - hostname: dev-cp-01
@@ -18,6 +18,11 @@ nodes:
   - hostname: dev-worker-01
     controlPlane: false
     ipAddress: 10.5.0.3
+    installDisk: /dev/vda
+
+  - hostname: dev-worker-02
+    controlPlane: false
+    ipAddress: 10.5.0.4
     installDisk: /dev/vda
 
 controlPlane:


### PR DESCRIPTION
## Summary

- Corrige le bootstrap dev Docker qui n'utilisait pas le `talconfig.yaml`
- Flannel est utilise au boot (requis par `talosctl cluster create docker`), puis remplace par Cilium via `make cilium`
- Ajout de `talos/dev/patch.yaml` applique via `--config-patch` (NFS modules, NTP, nameservers)
- 2 workers, 4Go RAM, 40Go disk par node
- Suppression automatique de flannel avant l'install Cilium en dev

## Test plan

- [x] `make destroy && make bootstrap` : cluster boot sans erreur
- [x] `make status` : 1 CP + 2 workers Ready, Cilium + CoreDNS Running