### PR TITLE
feat(cilium): activer LB IPAM avec L2 announcements

### DIFF
--- a/argocd/apps/cilium/kustomization.yaml
+++ b/argocd/apps/cilium/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 
 namespace: kube-system
 
+resources:
+  - ../../base/cilium
+
 helmCharts:
   - name: cilium
     namespace: kube-system

--- a/argocd/apps/cilium/values.yaml
+++ b/argocd/apps/cilium/values.yaml
@@ -30,6 +30,12 @@ cgroup:
     enabled: false
   hostRoot: /sys/fs/cgroup
 
+l2announcements:
+  enabled: true
+
+externalIPs:
+  enabled: true
+
 hubble:
   relay:
     enabled: true

--- a/argocd/base/cilium/ip-pool.yaml
+++ b/argocd/base/cilium/ip-pool.yaml
@@ -1,0 +1,8 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: default-pool
+spec:
+  blocks:
+    - start: 10.5.0.200
+      stop: 10.5.0.210

--- a/argocd/base/cilium/kustomization.yaml
+++ b/argocd/base/cilium/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ip-pool.yaml
+  - l2-policy.yaml

--- a/argocd/base/cilium/l2-policy.yaml
+++ b/argocd/base/cilium/l2-policy.yaml
@@ -1,0 +1,9 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: default-l2-policy
+spec:
+  loadBalancerIPs: true
+  interfaces:
+    - ^eth[0-9]+
+    - ^en[0-9]+


### PR DESCRIPTION
## Summary
- Active Cilium L2 announcements et LB IPAM pour attribuer des IPs aux services LoadBalancer
- Remplace le besoin de MetalLB sur bare metal
- Pool dev : `10.5.0.200-10.5.0.210`
- L2 policy annonce les IPs sur les interfaces eth/en des nodes

## Fichiers
- `argocd/apps/cilium/values.yaml` — ajout `l2announcements.enabled` et `externalIPs.enabled`
- `argocd/base/cilium/ip-pool.yaml` — CiliumLoadBalancerIPPool
- `argocd/base/cilium/l2-policy.yaml` — CiliumL2AnnouncementPolicy

## Test plan
- [x] Service ingress-nginx passe de `<pending>` à une IP dans `10.5.0.200-210`
- [x] Accès HTTP/HTTPS via l'IP attribuée depuis le Mac