### PR TITLE
feat(auth): intégrer Pocket-ID comme provider OIDC

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -13,3 +13,4 @@ ignore: |
   argocd/base/cert-manager/issuers/secret-cf-token.yaml
   argocd/base/democratic-csi/secrets/truenas-api-key.yaml
   argocd/base/pocket-id/secrets/pocket-id-secret.yaml
+  argocd/base/pocket-id/secrets/forward-auth-secret.yaml

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -12,3 +12,4 @@ rules:
 ignore: |
   argocd/base/cert-manager/issuers/secret-cf-token.yaml
   argocd/base/democratic-csi/secrets/truenas-api-key.yaml
+  argocd/base/pocket-id/secrets/pocket-id-secret.yaml

--- a/argocd/apps/cnpg/kustomization.yaml
+++ b/argocd/apps/cnpg/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: cnpg
+
+helmCharts:
+  - name: cloudnative-pg
+    namespace: cnpg
+    releaseName: cnpg
+    repo: https://cloudnative-pg.github.io/charts
+    valuesFile: values.yaml
+    version: 0.23.0
+    includeCRDs: true

--- a/argocd/apps/cnpg/values.yaml
+++ b/argocd/apps/cnpg/values.yaml
@@ -1,0 +1,2 @@
+crds:
+  create: true

--- a/argocd/apps/monitoring/ingressroute-grafana.yaml
+++ b/argocd/apps/monitoring/ingressroute-grafana.yaml
@@ -9,6 +9,9 @@ spec:
   routes:
     - match: Host(`grafana.streamixs.com`)
       kind: Rule
+      middlewares:
+        - name: pocket-id-auth
+          namespace: pocket-id
       services:
         - name: kube-prometheus-stack-grafana
           port: 80

--- a/argocd/apps/pocket-id/kustomization.yaml
+++ b/argocd/apps/pocket-id/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: pocket-id
+
+resources:
+  - ../../base/pocket-id

--- a/argocd/base/pocket-id/deployment.yaml
+++ b/argocd/base/pocket-id/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pocket-id
+  namespace: pocket-id
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pocket-id
+  template:
+    metadata:
+      labels:
+        app: pocket-id
+    spec:
+      containers:
+        - name: pocket-id
+          image: ghcr.io/pocket-id/pocket-id:v2
+          ports:
+            - name: http
+              containerPort: 1411
+          env:
+            - name: APP_URL
+              value: "https://auth.streamixs.com"
+            - name: TRUST_PROXY
+              value: "true"
+            - name: DB_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: pocket-id-db-app
+                  key: uri
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pocket-id-secret
+                  key: encryption-key
+          livenessProbe:
+            exec:
+              command:
+                - /app/pocket-id
+                - healthcheck
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - /app/pocket-id
+                - healthcheck
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/argocd/base/pocket-id/forward-auth-deployment.yaml
+++ b/argocd/base/pocket-id/forward-auth-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: INSECURE_COOKIE
               value: "false"
             - name: LOG_LEVEL
-              value: "debug"
+              value: "info"
           resources:
             requests:
               cpu: 50m

--- a/argocd/base/pocket-id/forward-auth-deployment.yaml
+++ b/argocd/base/pocket-id/forward-auth-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traefik-forward-auth
+  namespace: pocket-id
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: traefik-forward-auth
+  template:
+    metadata:
+      labels:
+        app: traefik-forward-auth
+    spec:
+      containers:
+        - name: traefik-forward-auth
+          image: thomseddon/traefik-forward-auth:2
+          ports:
+            - containerPort: 4181
+          env:
+            - name: DEFAULT_PROVIDER
+              value: "generic-oauth"
+            - name: PROVIDERS_GENERIC_OAUTH_AUTH_URL
+              value: "https://auth.streamixs.com/authorize"
+            - name: PROVIDERS_GENERIC_OAUTH_TOKEN_URL
+              value: "http://pocket-id.pocket-id.svc.cluster.local:1411/api/oidc/token"
+            - name: PROVIDERS_GENERIC_OAUTH_USER_URL
+              value: "http://pocket-id.pocket-id.svc.cluster.local:1411/api/oidc/userinfo"
+            - name: PROVIDERS_GENERIC_OAUTH_SCOPE
+              value: "openid email profile"
+            - name: PROVIDERS_GENERIC_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: forward-auth-secret
+                  key: client-id
+            - name: PROVIDERS_GENERIC_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: forward-auth-secret
+                  key: client-secret
+            - name: SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: forward-auth-secret
+                  key: cookie-secret
+            - name: AUTH_HOST
+              value: "auth.streamixs.com"
+            - name: COOKIE_DOMAIN
+              value: ".streamixs.com"
+            - name: INSECURE_COOKIE
+              value: "false"
+            - name: LOG_LEVEL
+              value: "info"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 64Mi

--- a/argocd/base/pocket-id/forward-auth-deployment.yaml
+++ b/argocd/base/pocket-id/forward-auth-deployment.yaml
@@ -18,6 +18,15 @@ spec:
           image: thomseddon/traefik-forward-auth:2
           ports:
             - containerPort: 4181
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: DEFAULT_PROVIDER
               value: "generic-oauth"
@@ -51,7 +60,7 @@ spec:
             - name: INSECURE_COOKIE
               value: "false"
             - name: LOG_LEVEL
-              value: "info"
+              value: "debug"
           resources:
             requests:
               cpu: 50m

--- a/argocd/base/pocket-id/forward-auth-deployment.yaml
+++ b/argocd/base/pocket-id/forward-auth-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: AUTH_HOST
               value: "auth.streamixs.com"
             - name: COOKIE_DOMAIN
-              value: ".streamixs.com"
+              value: "streamixs.com"
             - name: INSECURE_COOKIE
               value: "false"
             - name: LOG_LEVEL

--- a/argocd/base/pocket-id/forward-auth-ingressroute.yaml
+++ b/argocd/base/pocket-id/forward-auth-ingressroute.yaml
@@ -1,0 +1,18 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: forward-auth-callback
+  namespace: pocket-id
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`auth.streamixs.com`) && PathPrefix(`/_oauth`)
+      kind: Rule
+      middlewares:
+        - name: pocket-id-auth
+          namespace: pocket-id
+      services:
+        - name: traefik-forward-auth
+          port: 4181
+  tls: {}

--- a/argocd/base/pocket-id/forward-auth-service.yaml
+++ b/argocd/base/pocket-id/forward-auth-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik-forward-auth
+  namespace: pocket-id
+spec:
+  type: ClusterIP
+  selector:
+    app: traefik-forward-auth
+  ports:
+    - port: 4181
+      targetPort: 4181

--- a/argocd/base/pocket-id/generators/secret-generator.yaml
+++ b/argocd/base/pocket-id/generators/secret-generator.yaml
@@ -8,3 +8,4 @@ metadata:
         path: ksops
 files:
   - secrets/pocket-id-secret.yaml
+  - secrets/forward-auth-secret.yaml

--- a/argocd/base/pocket-id/generators/secret-generator.yaml
+++ b/argocd/base/pocket-id/generators/secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - secrets/pocket-id-secret.yaml

--- a/argocd/base/pocket-id/ingressroute.yaml
+++ b/argocd/base/pocket-id/ingressroute.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: pocket-id
+  namespace: pocket-id
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`auth.streamixs.com`)
+      kind: Rule
+      services:
+        - name: pocket-id
+          port: 1411
+  tls: {}

--- a/argocd/base/pocket-id/kustomization.yaml
+++ b/argocd/base/pocket-id/kustomization.yaml
@@ -9,6 +9,9 @@ resources:
   - service.yaml
   - ingressroute.yaml
   - middleware.yaml
+  - forward-auth-deployment.yaml
+  - forward-auth-service.yaml
+  - forward-auth-ingressroute.yaml
 
 generators:
   - generators/secret-generator.yaml

--- a/argocd/base/pocket-id/kustomization.yaml
+++ b/argocd/base/pocket-id/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: pocket-id
+
+resources:
+  - pg-cluster.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingressroute.yaml
+  - middleware.yaml
+
+generators:
+  - generators/secret-generator.yaml

--- a/argocd/base/pocket-id/middleware.yaml
+++ b/argocd/base/pocket-id/middleware.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: pocket-id
 spec:
   forwardAuth:
-    address: http://pocket-id.pocket-id.svc.cluster.local:1411/api/oidc/authorize
+    address: http://traefik-forward-auth.pocket-id.svc.cluster.local:4181
     authResponseHeaders:
       - X-Forwarded-User

--- a/argocd/base/pocket-id/middleware.yaml
+++ b/argocd/base/pocket-id/middleware.yaml
@@ -1,0 +1,10 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: pocket-id-auth
+  namespace: pocket-id
+spec:
+  forwardAuth:
+    address: http://pocket-id.pocket-id.svc.cluster.local:1411/api/oidc/authorize
+    authResponseHeaders:
+      - X-Forwarded-User

--- a/argocd/base/pocket-id/middleware.yaml
+++ b/argocd/base/pocket-id/middleware.yaml
@@ -6,5 +6,6 @@ metadata:
 spec:
   forwardAuth:
     address: http://traefik-forward-auth.pocket-id.svc.cluster.local:4181
+    trustForwardHeader: true
     authResponseHeaders:
       - X-Forwarded-User

--- a/argocd/base/pocket-id/pg-cluster.yaml
+++ b/argocd/base/pocket-id/pg-cluster.yaml
@@ -1,0 +1,16 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: pocket-id-db
+  namespace: pocket-id
+spec:
+  instances: 1
+
+  bootstrap:
+    initdb:
+      database: pocket-id
+      owner: pocket-id
+
+  storage:
+    size: 5Gi
+    storageClass: truenas-nfs

--- a/argocd/base/pocket-id/secrets/forward-auth-secret.example.yaml
+++ b/argocd/base/pocket-id/secrets/forward-auth-secret.example.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: forward-auth-secret
+  namespace: pocket-id
+type: Opaque
+stringData:
+  client-id: "<Pocket-ID OIDC Client ID>"
+  client-secret: "<Pocket-ID OIDC Client Secret>"
+  cookie-secret: "<generate with: openssl rand -hex 32>"

--- a/argocd/base/pocket-id/secrets/forward-auth-secret.yaml
+++ b/argocd/base/pocket-id/secrets/forward-auth-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: forward-auth-secret
+    namespace: pocket-id
+type: Opaque
+stringData:
+    client-id: ENC[AES256_GCM,data:9XKMmsiKqIYqrblTp1E8Boa7jd24FDEvXD3bQbVwcDsIBG1b,iv:Jyz1RUOmn4o0QgWRPfUEs6pswi+c7miME1Eiox99uq4=,tag:3jL8+bDZjmQjSwhi54l4sQ==,type:str]
+    client-secret: ENC[AES256_GCM,data:0b/vfRFcEHyRXQk1qQ0NFGCkDZn25GGr9QaJ3A6Hr5o=,iv:8Jq55Ehq8DbTO4uED1YyhxmZNufwqym0Zo/PZAFxTSs=,tag:OQ6jdGDmtuPpCBsBxNsFSA==,type:str]
+    cookie-secret: ENC[AES256_GCM,data:n7luCuXwXKbTk8lsFjgGA3fp1+3WgmpDvEh00cUG7/hAmH+uyEpPlDgXVOAp6CaqZmr29+CvtKI5LD0pMGczaw==,iv:E8M5c2UCJlnXX7qFZ2VzEYs7rDRk0jKVPp80k3ZfCT0=,tag:wa1Ji1RQ/XNbKykyOEFAvA==,type:str]
+sops:
+    age:
+        - recipient: age1tfhrx9u62qypvelr5padylmf3es8fc5qzlkg4y6qf266637sgs7sem52p9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4QUgzdkZnUkovTFFnTFdr
+            aG9kNWZiTzZzQTdFVkswZ2lKVjdxS042Nm4wCmxxWlB4dTBSazJOY2RBNUwzQnlz
+            ZWgzYTY3aWl1enIrNXFLOWErNlRIbncKLS0tIDNjRCtsQ3E1emNvRGhaalNrUzFL
+            Wk4xVXZmWEtTRjFxOHVBTFV6UnoxNkkKN6feZySC11NT0sN7LFDHA7qE/xEsmR2s
+            p+YDD1Ahx0lrzO8g5oSrDA6zkM6ysTKA9dpqaJGkFTyv2LmzGsFtkw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-03-25T09:31:48Z"
+    mac: ENC[AES256_GCM,data:0Kdd1HyiV7cil0PXeVtAQF4suVQ1mjBZCWFKmNjy/6xOHyRElTmJ3e+rESbRfJZvr9pL04S2q71r60q0gSpxj8NtVFK8+eiwJxEJRpY+vB8XsTQaB3++Dx9qnPTmkebKm1ChYMxNbCwxKkNIbufwPq/0qN0cCsXbojBUdUfQnSc=,iv:g/tLH/LC/9jGQzZeRdTGu+5B1rDhdl7mG09wtPIsp5U=,tag:MYwy/CeBfJ5EkXp/IIh5gQ==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.10.2

--- a/argocd/base/pocket-id/secrets/pocket-id-secret.example.yaml
+++ b/argocd/base/pocket-id/secrets/pocket-id-secret.example.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pocket-id-secret
+  namespace: pocket-id
+type: Opaque
+stringData:
+  encryption-key: "<generate with: openssl rand -hex 32>"

--- a/argocd/base/pocket-id/secrets/pocket-id-secret.yaml
+++ b/argocd/base/pocket-id/secrets/pocket-id-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: pocket-id-secret
+    namespace: pocket-id
+type: Opaque
+stringData:
+    encryption-key: ENC[AES256_GCM,data:6mcrfLQMEA/LhBDqfvuVL5hAEZKpj3M/bBNINYd2naQJQlDnO6PLBHmWOIZoJb6GXJVrc/gJoMJ7YSZ3LjIDbQ==,iv:tuFqu7ohe8mHbsMs8E28kRvl2/vVlN30K/ffED3A38k=,tag:cQU6Raku/irbs4cB6ZPdwQ==,type:str]
+sops:
+    age:
+        - recipient: age1tfhrx9u62qypvelr5padylmf3es8fc5qzlkg4y6qf266637sgs7sem52p9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0bmFTVi95aEpKK1RkM01T
+            V2pub2VOVm45bVdEMWlzRThpbkJLSVdIaEZ3Ck95bnMwWE5Qc2hIaTBnNWNTRHFN
+            MWxTdkd3TzFja29hemdYeVg4UHRabGsKLS0tIGJQWVdUaTVuNlVLYllBSEFkcGE5
+            Y2RRemRKUjIyNkExYmVIZWRmd2E4bVEKcVWPPuVYKSbDPqzM2JyRuEzRwuBode6j
+            4XI9+yMWz4vYU38TTV0KPkMwNSHyrfD7f7QYJJ7qW2rQuc5V4eCbjQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-03-25T08:19:26Z"
+    mac: ENC[AES256_GCM,data:TCl+dQamXb4kAIdeAMv9jaessRNcx4MrI+ptULgDuoStV/1ZDkHamQo07QWs3MdItcicYBPXHjPOTGD+fUr1p2ns5YEUQyH0PSiUJU5STvdpZulG22o8u3aKHt6zA6XDg8eCsg9lnaTEzkVfNr6+kU0BRLCzdj164+Y1nZ8pU70=,iv:UsIfzrKqGcPHu2poGzyeYdogw5WJDpCUw5kiD/oXpNA=,tag:CokIjpfGSaMUisH7gCa5tg==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.10.2

--- a/argocd/base/pocket-id/service.yaml
+++ b/argocd/base/pocket-id/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pocket-id
+  namespace: pocket-id
+spec:
+  type: ClusterIP
+  selector:
+    app: pocket-id
+  ports:
+    - port: 1411
+      targetPort: 1411

--- a/argocd/base/prowlarr/ingressroute.yaml
+++ b/argocd/base/prowlarr/ingressroute.yaml
@@ -9,6 +9,9 @@ spec:
   routes:
     - match: Host(`prowlarr.streamixs.com`)
       kind: Rule
+      middlewares:
+        - name: pocket-id-auth
+          namespace: pocket-id
       services:
         - name: prowlarr
           port: 9696

--- a/argocd/base/qbittorrent/ingressroute.yaml
+++ b/argocd/base/qbittorrent/ingressroute.yaml
@@ -9,6 +9,9 @@ spec:
   routes:
     - match: Host(`qbittorrent.streamixs.com`)
       kind: Rule
+      middlewares:
+        - name: pocket-id-auth
+          namespace: pocket-id
       services:
         - name: qbittorrent
           port: 8080

--- a/argocd/base/radarr/ingressroute.yaml
+++ b/argocd/base/radarr/ingressroute.yaml
@@ -9,6 +9,9 @@ spec:
   routes:
     - match: Host(`radarr.streamixs.com`)
       kind: Rule
+      middlewares:
+        - name: pocket-id-auth
+          namespace: pocket-id
       services:
         - name: radarr
           port: 7878

--- a/argocd/base/sonarr/ingressroute.yaml
+++ b/argocd/base/sonarr/ingressroute.yaml
@@ -9,6 +9,9 @@ spec:
   routes:
     - match: Host(`sonarr.streamixs.com`)
       kind: Rule
+      middlewares:
+        - name: pocket-id-auth
+          namespace: pocket-id
       services:
         - name: sonarr
           port: 8989

--- a/argocd/projects/platform.yaml
+++ b/argocd/projects/platform.yaml
@@ -16,6 +16,7 @@ spec:
     - https://argoproj.github.io/argo-helm
     - https://helm.cilium.io/
     - https://democratic-csi.github.io/charts/
+    - https://cloudnative-pg.github.io/charts
   destinations:
     - server: https://kubernetes.default.svc
       namespace: "*"


### PR DESCRIPTION
## Summary
- Déploie CloudNativePG (opérateur PostgreSQL) et Pocket-ID v2 comme provider OIDC avec passkeys
- PostgreSQL via CloudNativePG CRD comme backend (robuste, pas de problème NFS locking)
- Active le middleware Traefik forwardAuth sur prowlarr, radarr, sonarr, qbittorrent et grafana
- Secret ENCRYPTION_KEY chiffré via SOPS/KSOPS

## Post-déploiement
1. Vérifier les pods : `kubectl get pods -n cnpg && kubectl get pods -n pocket-id`
2. Accéder à `https://auth.streamixs.com/setup` pour créer le compte admin avec passkey
3. Tester l'accès à `prowlarr.streamixs.com` → redirection vers Pocket-ID

## Test plan
- [x] CNPG operator running dans le namespace `cnpg`
- [x] PostgreSQL cluster `pocket-id-db` ready dans `pocket-id`
- [x] Pocket-ID accessible sur `auth.streamixs.com`
- [x] Setup admin + passkey fonctionnel
- [x] Accès prowlarr/radarr/sonarr/qbittorrent/grafana redirige vers auth
- [x] Auth passkey → retour vers le service demandé