### PR TITLE
fix: corriger les tags d'images hotio

### DIFF
--- a/argocd/base/prowlarr/deployment.yaml
+++ b/argocd/base/prowlarr/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: prowlarr
-          image: ghcr.io/hotio/prowlarr:release-2.3.4
+          image: ghcr.io/hotio/prowlarr:2.3.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9696

--- a/argocd/base/prowlarr/deployment.yaml
+++ b/argocd/base/prowlarr/deployment.yaml
@@ -13,13 +13,12 @@ spec:
       labels:
         app: prowlarr
     spec:
-      # NE PAS forcer runAsUser/Group ici : s6 a besoin de root
       securityContext:
-        fsGroup: 1000                   # ok de garder, pas obligatoire
+        fsGroup: 1000
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: prowlarr
-          image: ghcr.io/hotio/prowlarr:2.3.4
+          image: lscr.io/linuxserver/prowlarr:2.3.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9696

--- a/argocd/base/prowlarr/deployment.yaml
+++ b/argocd/base/prowlarr/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: prowlarr
-          image: lscr.io/linuxserver/prowlarr:2.3.4
+          image: lscr.io/linuxserver/prowlarr:2.3.4-nightly
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9696

--- a/argocd/base/qbittorrent/deployment.yaml
+++ b/argocd/base/qbittorrent/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: qbittorrent
-          image: ghcr.io/hotio/qbittorrent:release-5.1.4
+          image: ghcr.io/hotio/qbittorrent:5.1.4
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/argocd/base/qbittorrent/deployment.yaml
+++ b/argocd/base/qbittorrent/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: qbittorrent
-          image: ghcr.io/hotio/qbittorrent:5.1.4
+          image: lscr.io/linuxserver/qbittorrent:5.1.4
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/argocd/base/radarr/deployment.yaml
+++ b/argocd/base/radarr/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: radarr
-          image: lscr.io/linuxserver/radarr:6.1.2
+          image: lscr.io/linuxserver/radarr:6.1.2-nightly
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/argocd/base/radarr/deployment.yaml
+++ b/argocd/base/radarr/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: radarr
-          image: ghcr.io/hotio/radarr:6.1.2
+          image: lscr.io/linuxserver/radarr:6.1.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/argocd/base/radarr/deployment.yaml
+++ b/argocd/base/radarr/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: radarr
-          image: ghcr.io/hotio/radarr:release-6.1.2
+          image: ghcr.io/hotio/radarr:6.1.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/argocd/base/sonarr/deployment.yaml
+++ b/argocd/base/sonarr/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: sonarr
-          image: ghcr.io/hotio/sonarr:release-4.0.17
+          image: ghcr.io/hotio/sonarr:4.0.17
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8989

--- a/argocd/base/sonarr/deployment.yaml
+++ b/argocd/base/sonarr/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: sonarr
-          image: ghcr.io/hotio/sonarr:4.0.17
+          image: lscr.io/linuxserver/sonarr:4.0.17
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8989


### PR DESCRIPTION
## Summary
- Corrige les tags des images hotio : supprime le prefixe `release-` pour utiliser uniquement le numero de version

## Changements
- qbittorrent: `release-5.1.4` → `5.1.4`
- sonarr: `release-4.0.17` → `4.0.17`
- radarr: `release-6.1.2` → `6.1.2`
- prowlarr: `release-2.3.4` → `2.3.4`

## Test plan
- [ ] ArgoCD sync sans erreur
- [ ] Les 4 pods redemarrent avec les bonnes images