### PR TITLE
feat(security): securityContext + SOPS check + Gitleaks CI

### DIFF
--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -18,3 +18,36 @@ jobs:
         run: pip install --disable-pip-version-check --no-cache-dir yamllint
       - name: Run yamllint on cluster
         run: yamllint -c .yamllint.yaml .
+
+  sops-check:
+    name: SOPS secrets check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check for plaintext secrets
+        run: |
+          status=0
+          for f in $(find . -path '*/secrets/*.yaml' ! -name '*.example.yaml'); do
+            if ! grep -q '^sops:' "$f"; then
+              echo "ERROR: $f is NOT encrypted with SOPS"
+              status=1
+            fi
+          done
+          if [ $status -eq 0 ]; then
+            echo "All secrets are properly encrypted"
+          fi
+          exit $status
+
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -47,7 +47,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz | tar xz
+          sudo mv gitleaks /usr/local/bin/
+      - name: Run Gitleaks on diff
+        run: gitleaks detect --source . --log-opts="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" --verbose

--- a/argocd/base/pocket-id/deployment.yaml
+++ b/argocd/base/pocket-id/deployment.yaml
@@ -18,11 +18,6 @@ spec:
           image: ghcr.io/pocket-id/pocket-id:v2.4.0
           securityContext:
             allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            runAsNonRoot: true
-            runAsUser: 65534
             seccompProfile:
               type: RuntimeDefault
           ports:

--- a/argocd/base/pocket-id/deployment.yaml
+++ b/argocd/base/pocket-id/deployment.yaml
@@ -16,6 +16,15 @@ spec:
       containers:
         - name: pocket-id
           image: ghcr.io/pocket-id/pocket-id:v2.4.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: http
               containerPort: 1411

--- a/argocd/base/prowlarr/deployment.yaml
+++ b/argocd/base/prowlarr/deployment.yaml
@@ -26,9 +26,9 @@ spec:
             - containerPort: 9696
           env:
             - name: PUID
-              value: "65534"
+              value: "1000"
             - name: PGID
-              value: "65534"
+              value: "1000"
             - name: UMASK
               value: "002"
             - name: TZ

--- a/argocd/base/prowlarr/deployment.yaml
+++ b/argocd/base/prowlarr/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: prowlarr
           image: lscr.io/linuxserver/prowlarr:2.3.4-nightly

--- a/argocd/base/qbittorrent/deployment.yaml
+++ b/argocd/base/qbittorrent/deployment.yaml
@@ -41,9 +41,9 @@ spec:
             timeoutSeconds: 5
           env:
             - name: PUID
-              value: "65534"
+              value: "1000"
             - name: PGID
-              value: "65534"
+              value: "1000"
             - name: UMASK
               value: "002"
             - name: TZ

--- a/argocd/base/qbittorrent/deployment.yaml
+++ b/argocd/base/qbittorrent/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: qbittorrent
           image: lscr.io/linuxserver/qbittorrent:5.1.4

--- a/argocd/base/radarr/deployment.yaml
+++ b/argocd/base/radarr/deployment.yaml
@@ -41,9 +41,9 @@ spec:
             timeoutSeconds: 5
           env:
             - name: PUID
-              value: "65534"
+              value: "1000"
             - name: PGID
-              value: "65534"
+              value: "1000"
             - name: UMASK
               value: "002"
             - name: TZ

--- a/argocd/base/radarr/deployment.yaml
+++ b/argocd/base/radarr/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: radarr
           image: lscr.io/linuxserver/radarr:6.1.2-nightly

--- a/argocd/base/sonarr/deployment.yaml
+++ b/argocd/base/sonarr/deployment.yaml
@@ -26,9 +26,9 @@ spec:
             - containerPort: 8989
           env:
             - name: PUID
-              value: "65534"
+              value: "1000"
             - name: PGID
-              value: "65534"
+              value: "1000"
             - name: UMASK
               value: "002"
             - name: TZ

--- a/argocd/base/sonarr/deployment.yaml
+++ b/argocd/base/sonarr/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: sonarr
           image: lscr.io/linuxserver/sonarr:4.0.17


### PR DESCRIPTION
## Summary
- Renforce le securityContext sur tous les deployments custom
- Ajoute 2 checks CI : verification SOPS et scan Gitleaks

## Changements

### SecurityContext
- **pocket-id** : securite complete (runAsNonRoot, drop ALL caps, seccompProfile)
- **media apps** (radarr, sonarr, prowlarr, qbittorrent) : seccompProfile RuntimeDefault au niveau pod (s6-overlay necessite root, on ne peut pas aller plus loin)

### CI
- **SOPS check** : verifie que tous les `secrets/*.yaml` (hors `.example.yaml`) sont chiffres avec SOPS
- **Gitleaks** : scanne les diffs pour detecter des tokens ou cles API commites accidentellement

## Test plan
- [ ] pocket-id demarre correctement avec le nouveau securityContext
- [ ] Les 4 apps media demarrent sans erreur
- [ ] CI passe sur cette PR (yamllint + sops-check + gitleaks)