### PR TITLE
fix(media): épingler toutes les images sur des tags stables

### DIFF
--- a/argocd/base/jellyseerr/deployment.yaml
+++ b/argocd/base/jellyseerr/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       initContainers:
         - name: fix-permissions
-          image: busybox
+          image: busybox:1.37.0
           command: ['sh', '-c', 'chown -R 1000:1000 /app/config']
           volumeMounts:
             - name: config

--- a/argocd/base/prowlarr/deployment.yaml
+++ b/argocd/base/prowlarr/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: prowlarr
-          image: lscr.io/linuxserver/prowlarr:2.3.4-nightly
+          image: lscr.io/linuxserver/prowlarr:2.3.5.5327-ls143
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9696

--- a/argocd/base/qbittorrent/deployment.yaml
+++ b/argocd/base/qbittorrent/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: qbittorrent
-          image: lscr.io/linuxserver/qbittorrent:5.1.4
+          image: lscr.io/linuxserver/qbittorrent:5.1.4-r3-ls451
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/argocd/base/radarr/deployment.yaml
+++ b/argocd/base/radarr/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: radarr
-          image: lscr.io/linuxserver/radarr:6.1.2-nightly
+          image: lscr.io/linuxserver/radarr:6.1.1.10360-ls300
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/argocd/base/sonarr/deployment.yaml
+++ b/argocd/base/sonarr/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: sonarr
-          image: lscr.io/linuxserver/sonarr:4.0.17
+          image: lscr.io/linuxserver/sonarr:4.0.17.2952-ls308
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8989


### PR DESCRIPTION
## Summary

- radarr: `6.1.2-nightly` → `6.1.1.10360-ls300` (stable)
- prowlarr: `2.3.4-nightly` → `2.3.5.5327-ls143` (stable)
- sonarr: `4.0.17` → `4.0.17.2952-ls308` (tag complet)
- qbittorrent: `5.1.4` → `5.1.4-r3-ls451` (tag complet)
- busybox: `(latest)` → `1.37.0` (initContainer jellyseerr)

## Test plan

- [ ] ArgoCD sync toutes les apps media Synced/Healthy
- [ ] Radarr, Sonarr, Prowlarr, qBittorrent démarrent correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)