### PR TITLE
chore(gitops): basculer targetRevision develop → main

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - develop
 
 jobs:
   gitleaks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ SOPS + Age encryption. The age key lives at `.config/age.agekey` (gitignored). K
 
 ### Key Config Details
 
-- ArgoCD currently targets the `develop` branch (to be changed to `main`)
+- ArgoCD targets the `main` branch
 - Dev kubeconfig: `~/.talos/kubeconfig-dev`, Prod: `~/.talos/kubeconfig-prod`
 - All ingresses use `*.streamixs.com` wildcard cert via cert-manager + Cloudflare DNS01
 - NFS provisioner points to `54.36.178.170:/export/k8s` (hardcoded)

--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,7 @@
 
 ## P3 — Amelioration
 
-- [ ] ArgoCD targetRevision : passer de `develop` a `main`
+- [x] ArgoCD targetRevision : passer de `develop` a `main`
 - [ ] Grafana persistence : PVC pour dashboards
 - [x] ~~NFS IP en variable~~ — remplace par democratic-csi + TrueNAS
 - [x] ~~Evaluer Cilium IngressController pour remplacer ingress-nginx~~ — migre vers Traefik (PR #67)

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -3,7 +3,7 @@
 Bootstrap et projets Argo CD pour l’environnement `dev`.
 
 ### Contenu
-- `bootstrap/app-of-apps.yaml`: Application Argo CD "app-of-apps" pointant vers `argocd/apps` sur la branche `develop`.
+- `bootstrap/app-of-apps.yaml`: Application Argo CD "app-of-apps" pointant vers `argocd/apps` sur la branche `main`.
 - `projects/platform.yaml`: Projet `platform` autorisant les sources Helm/repos nécessaires.
 - `apps/`: dossiers/fichiers d’applications synchronisées (référencés par le bootstrap).
 
@@ -25,7 +25,7 @@ Argo CD synchronise le contenu de `argocd/apps/*`. Chaque sous-dossier devient u
 
 ### Promotion / Multi-envs
 - Dupliquer `bootstrap/app-of-apps-<env>.yaml` et `projects/platform-<env>.yaml` en ajustant labels/env, `targetRevision`, `path`.
-- Utiliser des branches par environnement (`develop`, `staging`, `main`) ou des overlays Kustomize/valeurs Helm.
+- Utiliser des branches par environnement (`main`, `staging`) ou des overlays Kustomize/valeurs Helm.
 
 ### Applications gérées
 - `argo-rollouts`: installé via manifest upstream, namespace = `argo-rollouts`

--- a/argocd/bootstrap/app-of-apps.yaml
+++ b/argocd/bootstrap/app-of-apps.yaml
@@ -9,7 +9,7 @@ spec:
   generators:
     - git:
         repoURL: https://github.com/streamixs/cluster
-        revision: develop
+        revision: main
         directories:
           - path: argocd/apps/*
   template:
@@ -19,7 +19,7 @@ spec:
       project: platform
       source:
         repoURL: https://github.com/streamixs/cluster
-        targetRevision: develop
+        targetRevision: main
         path: argocd/apps/{{path.basename}}
       destination:
         server: https://kubernetes.default.svc


### PR DESCRIPTION
## Résumé

Migre toutes les références de branche `develop` → `main` pour fermer [#77](https://github.com/streamixs/cluster/issues/77).

**Workflow cible :**
```
feature/* → develop (intégration) → PR → main (production/ArgoCD)
```

### Fichiers modifiés

- **`argocd/bootstrap/app-of-apps.yaml`** — `revision` + `targetRevision` : `develop` → `main`
- **`.github/workflows/secret-scan.yml`** — supprime le trigger `push: develop` (ne reste que `main`)
- **`CLAUDE.md`** — met à jour la note sur la branche cible ArgoCD
- **`TODO.md`** — marque la tâche P3 comme complétée
- **`argocd/README.md`** — corrige les références de branche

## Ordre d'exécution post-merge (critique)

> ⚠️ Après le merge de cette PR dans `develop`, effectuer immédiatement les étapes suivantes.

**1. Créer la branche `main` depuis `develop`** (si elle n'existe pas encore)
```bash
git checkout develop && git pull
git checkout -b main
git push -u origin main
```

**2. Changer la branche par défaut GitHub** : Settings → General → Default branch → `main`
```bash
gh repo edit --default-branch main
```

**3. Vérifier ArgoCD** — les Applications doivent repasser en `Synced` en < 3 min
```bash
kubectl get applications -n argocd -o wide
```

**4. Tagger v0.1.0 sur `main`**
```bash
git checkout main
git tag -a v0.1.0 -m "Release v0.1.0 — premier tag stable"
git push origin v0.1.0
gh release create v0.1.0 --title "v0.1.0" \
  --notes "Premier tag de release stable. ArgoCD synchronise depuis \`main\`."
```

> `develop` est conservée comme branche d'intégration. Le flux normal : feature/* → develop → PR → main.

## Risques et mitigations

| Risque | Impact | Mitigation |
|--------|--------|------------|
| ArgoCD OutOfSync entre merge `develop` et création de `main` | < 3 min | Retry 3x configuré (backoff 5s→3m) — créer `main` immédiatement après merge |
| CI secret-scan ne scanne plus `develop` | Faible | Le scan reste actif sur toutes les PRs (`pull_request` trigger) |

## Plan de test

- [x] Yamllint verte en CI sur cette PR
- [x] Secret-scan verte en CI sur cette PR
- [ ] Après création de `main` : `kubectl get applications -n argocd` → tous `Synced`
- [ ] Tag `v0.1.0` visible dans GitHub Releases
- [ ] `grep -r "targetRevision" argocd/bootstrap/` → affiche `main`

Closes #77

🤖 Generated with [Claude Code](https://claude.ai/claude-code)