### PR TITLE
feat add stack prometeus loki and grafana

### DIFF
--- a/argocd/apps/monitoring/kustomization.yaml
+++ b/argocd/apps/monitoring/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+resources:
+  - namespace.yaml
+  - ../../base/monitoring
+
+helmCharts:
+  - name: kube-prometheus-stack
+    namespace: monitoring
+    releaseName: kps
+    repo: https://prometheus-community.github.io/helm-charts
+    version: 85.1.3
+    valuesFile: values-kube-prometheus-stack.yaml
+    includeCRDs: true
+  - name: loki
+    namespace: monitoring
+    releaseName: loki
+    repo: https://grafana.github.io/helm-charts
+    version: 7.0.0
+    valuesFile: values-loki.yaml
+    includeCRDs: true
+  - name: promtail
+    namespace: monitoring
+    releaseName: promtail
+    repo: https://grafana.github.io/helm-charts
+    version: 6.16.6
+    valuesFile: values-promtail.yaml
+    includeCRDs: true

--- a/argocd/apps/monitoring/namespace.yaml
+++ b/argocd/apps/monitoring/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/argocd/apps/monitoring/values-kube-prometheus-stack.yaml
+++ b/argocd/apps/monitoring/values-kube-prometheus-stack.yaml
@@ -1,0 +1,133 @@
+crds:
+  enabled: true
+
+defaultRules:
+  create: true
+
+alertmanager:
+  enabled: true
+  ingress:
+    enabled: false
+  alertmanagerSpec:
+    replicas: 1
+    retention: 120h
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: longhorn
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 5Gi
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+grafana:
+  enabled: true
+  adminPassword: changeme
+  defaultDashboardsEnabled: true
+  defaultDashboardsTimezone: Europe/Paris
+  persistence:
+    enabled: true
+    type: pvc
+    storageClassName: longhorn
+    accessModes: ["ReadWriteOnce"]
+    size: 5Gi
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      labelValue: "1"
+      searchNamespace: ALL
+      provider:
+        allowUiUpdates: true
+        foldersFromFilesStructure: true
+    datasources:
+      enabled: true
+      label: grafana_datasource
+      labelValue: "1"
+      searchNamespace: ALL
+  additionalDataSources:
+    - name: Loki
+      type: loki
+      access: proxy
+      url: http://loki-gateway.monitoring.svc.cluster.local
+      jsonData:
+        timeout: 60
+        maxLines: 1000
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  service:
+    type: ClusterIP
+
+prometheus:
+  enabled: true
+  ingress:
+    enabled: false
+  prometheusSpec:
+    replicas: 1
+    retention: 30d
+    retentionSize: "45GB"
+    scrapeInterval: 30s
+    evaluationInterval: 30s
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    probeSelectorNilUsesHelmValues: false
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: longhorn
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 50Gi
+    resources:
+      requests:
+        cpu: 250m
+        memory: 1Gi
+      limits:
+        cpu: 2000m
+        memory: 4Gi
+
+prometheusOperator:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  admissionWebhooks:
+    patch:
+      enabled: true
+
+kubeApiServer:
+  enabled: true
+kubelet:
+  enabled: true
+kubeControllerManager:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeProxy:
+  enabled: false
+kubeEtcd:
+  enabled: false
+coreDns:
+  enabled: true
+
+nodeExporter:
+  enabled: true
+kube-state-metrics:
+  enabled: true

--- a/argocd/apps/monitoring/values-loki.yaml
+++ b/argocd/apps/monitoring/values-loki.yaml
@@ -1,0 +1,102 @@
+deploymentMode: SingleBinary
+
+loki:
+  auth_enabled: false
+  schemaConfig:
+    configs:
+      - from: "2024-04-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+  storage:
+    type: filesystem
+    bucketNames:
+      chunks: chunks
+      ruler: ruler
+      admin: admin
+  limits_config:
+    retention_period: 720h
+    max_query_series: 10000
+    ingestion_rate_mb: 16
+    ingestion_burst_size_mb: 32
+    reject_old_samples: true
+    reject_old_samples_max_age: 168h
+  compactor:
+    retention_enabled: true
+    delete_request_store: filesystem
+  commonConfig:
+    replication_factor: 1
+
+singleBinary:
+  replicas: 1
+  persistence:
+    enabled: true
+    storageClass: longhorn
+    accessModes: ["ReadWriteOnce"]
+    size: 30Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1500m
+      memory: 1Gi
+
+backend:
+  replicas: 0
+read:
+  replicas: 0
+write:
+  replicas: 0
+ingester:
+  replicas: 0
+querier:
+  replicas: 0
+queryFrontend:
+  replicas: 0
+queryScheduler:
+  replicas: 0
+distributor:
+  replicas: 0
+compactor:
+  replicas: 0
+indexGateway:
+  replicas: 0
+bloomCompactor:
+  replicas: 0
+bloomGateway:
+  replicas: 0
+
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
+
+gateway:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+test:
+  enabled: false
+lokiCanary:
+  enabled: false
+
+monitoring:
+  selfMonitoring:
+    enabled: false
+    grafanaAgent:
+      installOperator: false
+  lokiCanary:
+    enabled: false
+  serviceMonitor:
+    enabled: true

--- a/argocd/apps/monitoring/values-promtail.yaml
+++ b/argocd/apps/monitoring/values-promtail.yaml
@@ -1,0 +1,27 @@
+daemonset:
+  enabled: true
+
+config:
+  clients:
+    - url: http://loki-gateway.monitoring.svc.cluster.local/loki/api/v1/push
+      tenant_id: ""
+  snippets:
+    pipelineStages:
+      - cri: {}
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+serviceMonitor:
+  enabled: true
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+  - effect: NoExecute
+    operator: Exists

--- a/argocd/base/monitoring/ingressroute-alertmanager.yaml
+++ b/argocd/base/monitoring/ingressroute-alertmanager.yaml
@@ -1,0 +1,18 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: alertmanager
+  namespace: monitoring
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`alertmanager.streamixs.com`)
+      kind: Rule
+      middlewares:
+        - name: forward-auth
+          namespace: auth
+      services:
+        - name: kps-kube-prometheus-stack-alertmanager
+          port: 9093
+  tls: {}

--- a/argocd/base/monitoring/ingressroute-grafana.yaml
+++ b/argocd/base/monitoring/ingressroute-grafana.yaml
@@ -1,0 +1,18 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`grafana.streamixs.com`)
+      kind: Rule
+      middlewares:
+        - name: forward-auth
+          namespace: auth
+      services:
+        - name: kps-grafana
+          port: 80
+  tls: {}

--- a/argocd/base/monitoring/ingressroute-prometheus.yaml
+++ b/argocd/base/monitoring/ingressroute-prometheus.yaml
@@ -1,0 +1,18 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`prometheus.streamixs.com`)
+      kind: Rule
+      middlewares:
+        - name: forward-auth
+          namespace: auth
+      services:
+        - name: kps-kube-prometheus-stack-prometheus
+          port: 9090
+  tls: {}

--- a/argocd/base/monitoring/kustomization.yaml
+++ b/argocd/base/monitoring/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ingressroute-grafana.yaml
+  - ingressroute-prometheus.yaml
+  - ingressroute-alertmanager.yaml

--- a/argocd/projects/platform.yaml
+++ b/argocd/projects/platform.yaml
@@ -18,6 +18,7 @@ spec:
     - https://charts.longhorn.io
     - https://cloudnative-pg.github.io/charts
     - https://immich-app.github.io/immich-charts
+    - https://grafana.github.io/helm-charts
   destinations:
     - server: https://kubernetes.default.svc
       namespace: "*"


### PR DESCRIPTION
## Summary

  - Add `monitoring` ArgoCD application bundling **kube-prometheus-stack** (v85.1.3), **Loki** (chart
  v7.0.0, SingleBinary) and **Promtail** (v6.16.6) in the `monitoring` namespace
  - Expose Grafana / Prometheus / Alertmanager via Traefik `IngressRoute` on `*.streamixs.com`, behind the
  Pocket-ID `forward-auth` middleware (same pattern as the rest of the cluster)
  - Register `https://grafana.github.io/helm-charts` in the `platform` AppProject `sourceRepos`

  Addresses roadmap priority #1 (« Aucun monitoring ») — cf. `ROADMAP.md`.

  ## Details

  **Storage (Longhorn RWO, replicas=2 per cluster default)**
  - Prometheus : 50Gi, retention 30j (`retentionSize: 45GB`)
  - Alertmanager : 5Gi, retention 120h
  - Grafana : 5Gi (SQLite + plugins)
  - Loki : 30Gi (filesystem store, retention 720h)

  **kube-prometheus-stack**
  - `serviceMonitorSelectorNilUsesHelmValues: false` → scrape les ServiceMonitor de tous les namespaces
  (Loki, Promtail, futurs apps)
  - `kubeControllerManager`, `kubeScheduler`, `kubeProxy`, `kubeEtcd` désactivés (Talos + Cilium kube-proxy
  replacement, endpoints non scrapables par défaut)
  - Grafana sidecar dashboards/datasources actif (label `grafana_dashboard=1` / `grafana_datasource=1`, all
  namespaces)
  - Loki préconfiguré comme datasource additionnelle dans Grafana

  **Loki**
  - Mode `SingleBinary` (1 replica), tous les autres composants (read/write/backend/ingester/…) à `replicas:
   0`
  - Gateway nginx exposée (`loki-gateway.monitoring.svc.cluster.local`) consommée par Grafana + Promtail
  - Compactor avec rétention activée

  **Promtail**
  - DaemonSet avec tolerations larges (NoSchedule + NoExecute) pour scraper les control-plane Talos
  - Pousse vers `http://loki-gateway.monitoring.svc.cluster.local/loki/api/v1/push`
  - ServiceMonitor activé

  **Ingress (all behind `auth/forward-auth`)**
  - `grafana.streamixs.com` → `kps-grafana:80`
  - `prometheus.streamixs.com` → `kps-kube-prometheus-stack-prometheus:9090`
  - `alertmanager.streamixs.com` → `kps-kube-prometheus-stack-alertmanager:9093`

  ## ⚠️  À noter

  - L'ApplicationSet (`argocd/bootstrap/app-of-apps.yaml`) pointe toujours sur `feat/media-music-stack`.
  Cette PR **ne sera pas auto-déployée** tant que le `targetRevision` n'aura pas migré vers `main` (cf.
  ROADMAP point #3). À mergeer en même temps que la bascule, ou suivre dans une PR dédiée.
  - `grafana.adminPassword: changeme` dans les values. Acceptable car l'UI est protégée par forward-auth +
  OIDC Pocket-ID, mais un secret SOPS serait plus propre — à faire dans un follow-up si on veut un login
  Grafana natif fonctionnel.

  ## Test plan

  - [x] `yamllint -c .yamllint.yaml .` passe
  - [x] `kustomize build --enable-helm argocd/apps/monitoring` produit des manifests valides
  - [x] Après sync ArgoCD (dev) : pods `kps-*`, `loki-*`, `promtail-*` Running
  - [x] PVC `longhorn` bound pour Prometheus / Alertmanager / Grafana / Loki
  - [x] `https://grafana.streamixs.com` redirige vers Pocket-ID puis affiche les dashboards par défaut
  - [x] Datasource Loki répond (Explore → `{namespace="media"}` retourne des logs)
  - [x] Targets Prometheus : `up == 1` pour kubelet, node-exporter, kube-state-metrics, Loki, Promtail
  - [x] Idem sur cluster prod après merge