### PR TITLE
feat(ci): configure Renovate Bot (auto-merge patches)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,92 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  extends: [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":timezone(Europe/Paris)",
+  ],
+
+  baseBranches: ["develop"],
+  labels: ["renovate"],
+  assignees: ["code-ex0"],
+
+  prHourlyLimit: 4,
+  prConcurrentLimit: 10,
+  rebaseWhen: "behind-base-branch",
+
+  // GitHub native auto-merge — exige "Allow auto-merge" activé dans la
+  // branch protection de develop. Sinon Renovate fait un merge classique.
+  platformAutomerge: true,
+
+  packageRules: [
+    {
+      // Auto-merge patch / pin / digest pour Docker, Helm, GHA et custom regex.
+      // Minor et major restent manuels.
+      matchUpdateTypes: ["patch", "pin", "digest"],
+      matchManagers: [
+        "dockerfile",
+        "kubernetes",
+        "kustomize",
+        "helmv3",
+        "helm-values",
+        "github-actions",
+        "custom.regex",
+      ],
+      automerge: true,
+    },
+    {
+      // Stack LinuxServer.io: une seule PR par cycle (sonarr/radarr/lidarr/...).
+      matchDatasources: ["docker"],
+      matchPackageNames: ["lscr.io/linuxserver/**"],
+      groupName: "linuxserver images",
+    },
+    {
+      matchManagers: ["github-actions"],
+      groupName: "github-actions",
+    },
+    {
+      // Control plane: jamais d'auto-bump. Upgrade pilote via Makefile
+      // (etcd-backup -> k8s-upgrade-check -> k8s-upgrade).
+      matchPackageNames: [
+        "ghcr.io/siderolabs/talos",
+        "ghcr.io/siderolabs/installer",
+        "registry.k8s.io/kube-apiserver",
+      ],
+      enabled: false,
+    },
+    {
+      // Helm minor: peut amener des changements de CRD => pas d'auto-merge.
+      matchManagers: ["helmv3", "kustomize"],
+      matchDatasources: ["helm"],
+      matchUpdateTypes: ["minor"],
+      automerge: false,
+    },
+    {
+      matchUpdateTypes: ["major"],
+      automerge: false,
+      addLabels: ["major-update"],
+    },
+  ],
+
+  customManagers: [
+    {
+      // Gitleaks epingle via variable shell annotee dans secret-scan.yml
+      customType: "regex",
+      fileMatch: ["^\\.github/workflows/secret-scan\\.ya?ml$"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+GITLEAKS_VERSION:\\s*(?<currentValue>[\\d.]+)",
+      ],
+    },
+  ],
+
+  vulnerabilityAlerts: {
+    enabled: true,
+    labels: ["security", "renovate"],
+    automerge: true,
+  },
+
+  // Heures off-peak (Europe/Paris) pour ne pas saturer ArgoCD en journee.
+  schedule: ["after 22:00 every weekday", "every weekend"],
+}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -17,8 +17,12 @@ jobs:
           fetch-depth: 0
 
       - name: Install gitleaks
+        env:
+          # renovate: datasource=github-releases depName=gitleaks/gitleaks
+          GITLEAKS_VERSION: 8.30.1
         run: |
-          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+          base="https://github.com/gitleaks/gitleaks/releases/download"
+          curl -sSfL "${base}/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | tar -xz -C /usr/local/bin gitleaks
 
       - name: Run gitleaks

--- a/README.md
+++ b/README.md
@@ -67,3 +67,16 @@ Setup TrueNAS :
 ### Secrets
 
 Managed with SOPS + Age. Key at `.config/age.agekey` (gitignored).
+
+### Dependency updates
+
+[Renovate Bot](https://www.mend.io/renovate/) ouvre des PRs ciblant `develop` pour bumper les images Docker, les charts Helm (`kustomize.helmCharts`) et les actions GitHub. Config dans [`.github/renovate.json5`](.github/renovate.json5).
+
+- **Patches** (`x.y.Z`) : auto-merge active si la branch protection de `develop` autorise l'auto-merge GitHub.
+- **Minor / major** : PR a valider manuellement.
+- **Talos / Kubernetes / installer Sidero** : exclus de Renovate, upgrade pilote via `make k8s-upgrade-check` + `make etcd-backup`.
+- **Schedule** : nuits de semaine (apres 22h) + weekends, fuseau Europe/Paris.
+
+Une *Dependency Dashboard* (issue auto-creee par Renovate) liste les PRs en cours et les bumps en attente.
+
+Activation : installer [l'app Mend Renovate](https://github.com/apps/renovate) sur le repo `streamixs/cluster`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,9 +30,9 @@ Action : Velero + S3 (MinIO sur TrueNAS) + verif crons.
 `argocd/bootstrap/app-of-apps.yaml` : `revision: feat/media-music-stack`.
 Le TODO disait pourtant "develop -> main". A fixer immediatement.
 
-### 4. Tags d'images flottants
-- `ghcr.io/autobrr/qui:latest` (critique)
-- `thomseddon/traefik-forward-auth:2` (mineur)
+### 4. ~~Tags d'images flottants~~ (fix avec Renovate)
+- ~~`ghcr.io/autobrr/qui:latest`~~ -> `v1.18.0`
+- ~~`thomseddon/traefik-forward-auth:2`~~ -> `2.3.0`
 
 ### 5. Probes manquantes
 Manque liveness/readiness sur : `prowlarr`, `sonarr`, `lidarr`, `tautulli`, `traefik-forward-auth`.
@@ -66,8 +66,8 @@ Cilium installe mais aucune segmentation. Un pod compromis peut taper partout.
 ## A ajouter (par ROI decroissant)
 
 ### Priorite haute
-1. **Stack monitoring** : kube-prometheus-stack + loki-stack + promtail
-2. **Renovate Bot** : auto-PR pour images + Helm charts (auto-merge patches)
+1. ~~**Stack monitoring** : kube-prometheus-stack + loki-stack + promtail~~ (fait #87)
+2. ~~**Renovate Bot** : auto-PR pour images + Helm charts (auto-merge patches)~~ (config `.github/renovate.json5`)
 3. **CI validation** : `kustomize build` + `kubeconform` sur chaque app
 4. **Velero** + S3 (MinIO TrueNAS) pour backup manifests + PV snapshots
 5. **NetworkPolicies de base** : deny-all par namespace + allow explicit
@@ -94,8 +94,8 @@ Cilium installe mais aucune segmentation. Un pod compromis peut taper partout.
 
 ## Top 5 actions immediates
 
-1. Fixer `app-of-apps.yaml` -> `revision: main`
-2. Deployer kube-prometheus-stack
-3. Pin `qui:latest` -> version concrete
-4. Renovate Bot
+1. ~~Fixer `app-of-apps.yaml` -> `revision: main`~~ (#83, develop pour l'instant)
+2. ~~Deployer kube-prometheus-stack~~ (#87)
+3. ~~Pin `qui:latest` -> version concrete~~ (v1.18.0)
+4. ~~Renovate Bot~~ (`.github/renovate.json5`)
 5. Strategie de backup (Velero ou cron Longhorn snapshots minimum)

--- a/argocd/base/qui/deployment.yaml
+++ b/argocd/base/qui/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: qui
-          image: ghcr.io/autobrr/qui:latest
+          image: ghcr.io/autobrr/qui:v1.18.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/argocd/base/traefik-forward-auth/deployment.yaml
+++ b/argocd/base/traefik-forward-auth/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: traefik-forward-auth
-          image: thomseddon/traefik-forward-auth:2
+          image: thomseddon/traefik-forward-auth:2.3.0
           ports:
             - containerPort: 4181
           securityContext:


### PR DESCRIPTION
## Summary

Met en place **Renovate Bot** sur le repo pour automatiser les bumps d'images Docker, charts Helm, GitHub Actions et la version de gitleaks. Couvre les points 2, 3 et 4 de la roadmap.

## Ce que la config fait

- **Managers actifs** : `kustomize` (helmCharts dans `argocd/apps/*/`), `kubernetes` (images Deployments), `helm-values`, `github-actions`, custom regex pour `GITLEAKS_VERSION`
- **Auto-merge patch / pin / digest** sur Docker + Helm + GHA + regex via GitHub native auto-merge
- **Minor Helm** = PR manuelle (risque de breaking change CRD)
- **Major** = PR manuelle avec label `major-update`
- **Talos / Sidero installer / kube-apiserver** exclus : l'upgrade control-plane reste piloté par `make k8s-upgrade-check` + `make etcd-backup`
- Stack **LinuxServer.io** regroupée en une seule PR par cycle
- **GitHub Actions** regroupées en une seule PR
- **Schedule** : nuits semaine (>22h Europe/Paris) + weekends, pour ne pas spam ArgoCD en journée
- **Vulnerability alerts** : auto-merge prioritaire avec label `security`
- **Dependency Dashboard** : issue auto-créée par Renovate pour suivre l'état

Config validée par `renovate-config-validator` (Mend officiel).

## Changements connexes

- `secret-scan.yml` : `GITLEAKS_VERSION` extrait en variable `env:` avec annotation `# renovate: ...` que le customManager regex pourra bumper
- `argocd/base/qui/deployment.yaml` : `ghcr.io/autobrr/qui:latest` → `v1.18.0` (Renovate ne peut pas bumper un tag flottant)
- `argocd/base/traefik-forward-auth/deployment.yaml` : `thomseddon/traefik-forward-auth:2` → `2.3.0`
- `README.md` : nouvelle section "Dependency updates"
- `ROADMAP.md` : items #2 (Renovate), #3 (app-of-apps revision) et #4 (tags flottants) marqués comme faits

## Activation post-merge

1. Installer [l'app Mend Renovate](https://github.com/apps/renovate) sur `streamixs/cluster`
2. Activer **Allow auto-merge** dans la branch protection de `develop` (sinon `platformAutomerge` retombe sur un merge classique au lieu du natif GitHub)
3. La première PR Renovate sera l'onboarding "Configure Renovate" : la merger pour démarrer le cycle

## Test plan

- [x] La PR passe yamllint + gitleaks (CI)
- [ ] Après merge, installer l'app Mend Renovate sur le repo
- [ ] Vérifier la dashboard issue créée par Renovate
- [ ] Première bump auto-mergée (probablement un patch lscr.io/linuxserver/*)
- [ ] Vérifier qu'aucune PR n'apparaît pour Talos / kube-apiserver