### PR TITLE
fix(renovate): enable kubernetes manager + annotate immich tag

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,13 +70,28 @@
     },
   ],
 
+  // Manager kubernetes: pas active par defaut, on opt-in sur argocd/base
+  // pour que Renovate detecte les `image:` dans les Deployments / StatefulSets.
+  kubernetes: {
+    managerFilePatterns: ["/^argocd/base/.+\\.ya?ml$/"],
+  },
+
   customManagers: [
     {
       // Gitleaks epingle via variable shell annotee dans secret-scan.yml
       customType: "regex",
-      fileMatch: ["^\\.github/workflows/secret-scan\\.ya?ml$"],
+      managerFilePatterns: ["/^\\.github/workflows/secret-scan\\.ya?ml$/"],
       matchStrings: [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+GITLEAKS_VERSION:\\s*(?<currentValue>[\\d.]+)",
+      ],
+    },
+    {
+      // Tag pin annote dans Helm values (ex: argocd/base/immich/values.yaml).
+      // Pattern: ligne `# renovate: datasource=X depName=Y` suivie de `tag: vX.Y.Z`.
+      customType: "regex",
+      managerFilePatterns: ["/(^|/)values\\.ya?ml$/"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+tag:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
       ],
     },
   ],

--- a/argocd/base/immich/values.yaml
+++ b/argocd/base/immich/values.yaml
@@ -3,6 +3,7 @@ controllers:
     containers:
       main:
         image:
+          # renovate: datasource=docker depName=ghcr.io/immich-app/immich-server
           tag: v2.7.5
         env:
           DB_HOSTNAME: immich-db-rw

--- a/argocd/base/traefik-forward-auth/deployment.yaml
+++ b/argocd/base/traefik-forward-auth/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: traefik-forward-auth
-          image: thomseddon/traefik-forward-auth:2.3.0
+          image: thomseddon/traefik-forward-auth:2
           ports:
             - containerPort: 4181
           securityContext:


### PR DESCRIPTION
## Pourquoi

L'issue [#91](https://github.com/streamixs/cluster/issues/91) (Dependency Dashboard) montre que Renovate detecte les `helmCharts:` via le manager `kustomize`, mais **ignore toutes les images Docker** des Deployments/StatefulSets dans `argocd/base/*`. Cause : le manager `kubernetes` de Renovate exige un `managerFilePatterns` explicite (pas activé par défaut), au contraire de `kustomize` ou `github-actions`.

Conséquence actuelle : sonarr, radarr, lidarr, prowlarr, qbittorrent (+ seed), plex, jellyseerr, tautulli, qui, mixarr et traefik-forward-auth ne sont pas trackés.

## Ce que change la PR

- Active `kubernetes.managerFilePatterns` sur `argocd/base/.+\.ya?ml$`
- Ajoute un customManager regex générique pour les annotations `# renovate: datasource=X depName=Y` au-dessus de `tag:` dans les fichiers `values.yaml`
- Annote `argocd/base/immich/values.yaml` (`tag: v2.7.5`) pour que Renovate bumpe le tag Immich (l'app Helm de Immich passe l'image via `tag:` dans les values, pas via un `image:` standard k8s)
- Migre `fileMatch` → `managerFilePatterns` pour aligner avec ce que demande la "Config Migration" du dashboard (champ moderne Renovate 41+)

Config validée par `renovate-config-validator`.

## Test plan

- [ ] yamllint passe
- [ ] gitleaks passe
- [ ] Une fois mergée sur develop puis promue sur main, le dashboard Renovate doit lister :
  - Les images `lscr.io/linuxserver/*` (groupées)
  - `ghcr.io/autobrr/qui` (v1.18.0)
  - `thomseddon/traefik-forward-auth` (2.3.0)
  - `plexinc/pms-docker`, `busybox`, `ghcr.io/seerr-team/seerr`, `ghcr.io/aquantumofdonuts/mixarr`
  - `ghcr.io/immich-app/immich-server` (via l'annotation values)