### PR TITLE
feat(ci): kustomize build + kubeconform validation par app

### DIFF
--- a/.github/workflows/validate-kustomize.yml
+++ b/.github/workflows/validate-kustomize.yml
@@ -1,0 +1,102 @@
+name: Validate kustomize + kubeconform
+
+on:
+  pull_request:
+    paths:
+      - "argocd/**"
+      - ".github/workflows/validate-kustomize.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "argocd/**"
+      - ".github/workflows/validate-kustomize.yml"
+
+permissions:
+  contents: read
+
+env:
+  KUSTOMIZE_VERSION: 5.6.0
+  KUBECONFORM_VERSION: 0.6.7
+  HELM_VERSION: v3.16.4
+  KUBERNETES_VERSION: "1.32.0"
+
+jobs:
+  discover:
+    name: Discover apps
+    runs-on: ubuntu-latest
+    outputs:
+      apps: ${{ steps.list.outputs.apps }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: List apps
+        id: list
+        run: |
+          apps=$(ls -d argocd/apps/*/ | xargs -n1 basename | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "apps=${apps}" >> "$GITHUB_OUTPUT"
+          echo "Discovered apps: ${apps}"
+
+  validate:
+    name: ${{ matrix.app }}
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: ${{ fromJson(needs.discover.outputs.apps) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Install kustomize
+        run: |
+          base="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize"
+          curl -sSfL "${base}/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin kustomize
+          kustomize version
+
+      - name: Install kubeconform
+        run: |
+          curl -sSfL "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin kubeconform
+          kubeconform -v
+
+      - name: Render app with kustomize
+        id: build
+        run: |
+          set +e
+          out=$(kustomize build --enable-helm "argocd/apps/${{ matrix.app }}" 2> build.err)
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            if grep -qE "ksops|exec plugin|plugin.*not.*found" build.err; then
+              echo "::warning ::App '${{ matrix.app }}' utilise KSOPS, validation kustomize-build skippée (decrypt impossible en CI)."
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error ::kustomize build a échoué pour '${{ matrix.app }}':"
+            cat build.err
+            exit "$rc"
+          fi
+          echo "$out" > rendered.yaml
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          echo "Rendered $(grep -c '^kind:' rendered.yaml || echo 0) resources."
+
+      - name: Validate with kubeconform
+        if: steps.build.outputs.skipped != 'true'
+        # CRDs (Traefik, cert-manager, CNPG, Longhorn, etc.) ne sont pas
+        # validés faute de catalogue compatible avec le template kubeconform
+        # (casing minuscule des fichiers). -ignore-missing-schemas les
+        # accepte sans bloquer. La validation reste stricte sur les types
+        # K8s core.
+        run: |
+          kubeconform \
+            -strict \
+            -summary \
+            -kubernetes-version "${KUBERNETES_VERSION}" \
+            -schema-location default \
+            -ignore-missing-schemas \
+            rendered.yaml

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,7 @@ Cilium installe mais aucune segmentation. Un pod compromis peut taper partout.
 ### Priorite haute
 1. ~~**Stack monitoring** : kube-prometheus-stack + loki-stack + promtail~~ (fait #87)
 2. ~~**Renovate Bot** : auto-PR pour images + Helm charts (auto-merge patches)~~ (config `.github/renovate.json5`)
-3. **CI validation** : `kustomize build` + `kubeconform` sur chaque app
+3. ~~**CI validation** : `kustomize build` + `kubeconform` sur chaque app~~ (`validate-kustomize.yml`)
 4. **Velero** + S3 (MinIO TrueNAS) pour backup manifests + PV snapshots
 5. **NetworkPolicies de base** : deny-all par namespace + allow explicit
 


### PR DESCRIPTION
## Summary

Roadmap P0 #3 : valider tous les manifests rendus à chaque PR.
Nouveau workflow [`validate-kustomize.yml`](.github/workflows/validate-kustomize.yml) qui :

1. **Discover** : matrix auto-générée à partir des sous-dossiers de `argocd/apps/`
2. **Per app** : `kustomize build --enable-helm` → `kubeconform -strict`

## Apps validées (9/12)

argo-rollouts, argocd, cilium, cloudnative-pg, external-services, immich, longhorn, monitoring, traefik

Testé en local, **0 invalid / 0 errors** sur les 9 apps. Les ressources skipped sont des CRDs (Traefik IngressRoute, Cilium L2 policies, CNPG Cluster, Longhorn, ServiceMonitor, etc.).

## Apps skippées (3/12)

cert-manager, traefik-forward-auth, media → contiennent des generators KSOPS, decryption impossible en CI (pas d'age key). Le workflow détecte le pattern d'erreur "ksops" et émet un warning (pas un fail) pour ne pas bloquer la PR.

Si on veut un jour valider ces apps aussi, deux options :
- Ajouter une clé age dédiée CI comme second recipient SOPS (re-chiffrer les 4 fichiers, ajouter `SOPS_AGE_CI_KEY` en secret repo)
- Installer KSOPS dans le runner + restorer l'age key depuis un secret

À voir plus tard si besoin.

## Trade-off CRD validation

Les CRDs custom (Traefik, CNPG, etc.) ne sont **pas** validés contre leurs schemas. Cause : le template kubeconform ne supporte pas `{{.ResourceKind | lower}}` qui serait nécessaire pour fetch le datreeio CRDs-catalog (noms de fichiers en minuscules). `-ignore-missing-schemas` les accepte sans bloquer. Le gros de la valeur de la validation reste : typos `apiVersion`/`kind`, types incorrects, champs requis manquants sur tous les types K8s core.

## Test plan

- [x] Test local : 9 apps valident (0 invalid, 0 errors)
- [x] Test local : 3 apps KSOPS échouent avec le pattern attendu (catché par grep)
- [x] yamllint passe
- [x] CI passe sur cette PR