### PR TITLE
fix(media): durcir la resilience de qbittorrent et qbittorrent-seed

### DIFF
--- a/argocd/base/cilium/l2-policy.yaml
+++ b/argocd/base/cilium/l2-policy.yaml
@@ -4,6 +4,13 @@ metadata:
   name: default-l2-policy
 spec:
   loadBalancerIPs: true
+  # Le control-plane a allowSchedulingOnControlPlanes: false, aucun pod n'y
+  # tournera jamais. Le laisser candidat a l'election du leader L2 lui fait
+  # annoncer des IP de services qu'il ne peut pas servir localement.
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
   interfaces:
     - ^eth[0-9]+
     - ^eno[0-9]+

--- a/argocd/base/qbittorrent-seed/deployment.yaml
+++ b/argocd/base/qbittorrent-seed/deployment.yaml
@@ -15,8 +15,13 @@ spec:
       labels:
         app: qbittorrent-seed
     spec:
+      # qBittorrent ecrit ses .fastresume a l'arret. Trop court = SIGKILL =
+      # recheck complet de tous les torrents au redemarrage (des heures sur NFS).
+      terminationGracePeriodSeconds: 300
       securityContext:
-        fsGroup: 1000
+        # Doit matcher PUID/PGID ci-dessous, sinon le kubelet peut declencher
+        # un chgrp recursif sur les 9Ti de media-pv.
+        fsGroup: 65534
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: qbittorrent-seed
@@ -38,6 +43,9 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
+            # La WebUI ne repond pas pendant un recheck ou une saturation IO NFS.
+            # Le defaut (3 = 90s) tue le pod et relance un recheck : boucle infinie.
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /

--- a/argocd/base/qbittorrent-seed/service.yaml
+++ b/argocd/base/qbittorrent-seed/service.yaml
@@ -26,9 +26,14 @@ metadata:
     lbipam.cilium.io/ips: "192.168.1.220"
 spec:
   type: LoadBalancer
-  # Preserve l'IP source des peers et garantit que seul le node hebergeant le pod
-  # annonce l'IP en ARP.
-  externalTrafficPolicy: Local
+  # Cluster et non Local : l'election du leader L2 de Cilium 1.17 ne tient pas
+  # compte des endpoints, le node qui annonce l'IP en ARP n'est donc pas
+  # forcement celui qui heberge le pod. En Local il ne peut pas relayer et le
+  # kernel repond RST (Connection refused). En Cluster n'importe quel node
+  # relaie, ce qui rend le placement du pod indifferent.
+  # Contrepartie : SNAT, qBittorrent voit les peers entrants avec l'IP du node
+  # relais. Sans effet sur la connectabilite ni sur le ratio.
+  externalTrafficPolicy: Cluster
   # Cilium sert le trafic LB directement, les nodePorts sont inutiles.
   allocateLoadBalancerNodePorts: false
   selector:

--- a/argocd/base/qbittorrent-seed/service.yaml
+++ b/argocd/base/qbittorrent-seed/service.yaml
@@ -11,14 +11,26 @@ spec:
     - port: 8080
       targetPort: 8080
 ---
+# LoadBalancer plutot que NodePort : avec externalTrafficPolicy Local, un NodePort
+# n'est joignable que sur le node qui heberge le pod. Le pod n'ayant pas d'affinite,
+# tout reschedule (drain, upgrade Talos, OOM) rendait le port BT injoignable en
+# silence -- le pod reste Running, seul le ratio s'effondre.
+# L'IP du LB suit le pod via les L2 announcements Cilium : le port-forward du
+# routeur pointe vers cette IP une fois pour toutes.
 apiVersion: v1
 kind: Service
 metadata:
   name: qbittorrent-seed-bt
   namespace: media
+  annotations:
+    lbipam.cilium.io/ips: "192.168.1.220"
 spec:
-  type: NodePort
+  type: LoadBalancer
+  # Preserve l'IP source des peers et garantit que seul le node hebergeant le pod
+  # annonce l'IP en ARP.
   externalTrafficPolicy: Local
+  # Cilium sert le trafic LB directement, les nodePorts sont inutiles.
+  allocateLoadBalancerNodePorts: false
   selector:
     app: qbittorrent-seed
   ports:
@@ -26,9 +38,7 @@ spec:
       protocol: TCP
       port: 30882
       targetPort: 30882
-      nodePort: 30882
     - name: bt-udp
       protocol: UDP
       port: 30882
       targetPort: 30882
-      nodePort: 30882

--- a/argocd/base/qbittorrent/deployment.yaml
+++ b/argocd/base/qbittorrent/deployment.yaml
@@ -15,8 +15,13 @@ spec:
       labels:
         app: qbittorrent
     spec:
+      # qBittorrent ecrit ses .fastresume a l'arret. Trop court = SIGKILL =
+      # recheck complet de tous les torrents au redemarrage (des heures sur NFS).
+      terminationGracePeriodSeconds: 300
       securityContext:
-        fsGroup: 1000
+        # Doit matcher PUID/PGID ci-dessous, sinon le kubelet peut declencher
+        # un chgrp recursif sur les 9Ti de media-pv.
+        fsGroup: 65534
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: qbittorrent
@@ -38,6 +43,9 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
+            # La WebUI ne repond pas pendant un recheck ou une saturation IO NFS.
+            # Le defaut (3 = 90s) tue le pod et relance un recheck : boucle infinie.
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /

--- a/argocd/base/qbittorrent/service.yaml
+++ b/argocd/base/qbittorrent/service.yaml
@@ -26,9 +26,14 @@ metadata:
     lbipam.cilium.io/ips: "192.168.1.219"
 spec:
   type: LoadBalancer
-  # Preserve l'IP source des peers et garantit que seul le node hebergeant le pod
-  # annonce l'IP en ARP.
-  externalTrafficPolicy: Local
+  # Cluster et non Local : l'election du leader L2 de Cilium 1.17 ne tient pas
+  # compte des endpoints, le node qui annonce l'IP en ARP n'est donc pas
+  # forcement celui qui heberge le pod. En Local il ne peut pas relayer et le
+  # kernel repond RST (Connection refused). En Cluster n'importe quel node
+  # relaie, ce qui rend le placement du pod indifferent.
+  # Contrepartie : SNAT, qBittorrent voit les peers entrants avec l'IP du node
+  # relais. Sans effet sur la connectabilite ni sur le ratio.
+  externalTrafficPolicy: Cluster
   # Cilium sert le trafic LB directement, les nodePorts sont inutiles.
   allocateLoadBalancerNodePorts: false
   selector:

--- a/argocd/base/qbittorrent/service.yaml
+++ b/argocd/base/qbittorrent/service.yaml
@@ -11,14 +11,26 @@ spec:
     - port: 8080
       targetPort: 8080
 ---
+# LoadBalancer plutot que NodePort : avec externalTrafficPolicy Local, un NodePort
+# n'est joignable que sur le node qui heberge le pod. Le pod n'ayant pas d'affinite,
+# tout reschedule (drain, upgrade Talos, OOM) rendait le port BT injoignable en
+# silence -- le pod reste Running, seul le ratio s'effondre.
+# L'IP du LB suit le pod via les L2 announcements Cilium : le port-forward du
+# routeur pointe vers cette IP une fois pour toutes.
 apiVersion: v1
 kind: Service
 metadata:
   name: qbittorrent-bt
   namespace: media
+  annotations:
+    lbipam.cilium.io/ips: "192.168.1.219"
 spec:
-  type: NodePort
+  type: LoadBalancer
+  # Preserve l'IP source des peers et garantit que seul le node hebergeant le pod
+  # annonce l'IP en ARP.
   externalTrafficPolicy: Local
+  # Cilium sert le trafic LB directement, les nodePorts sont inutiles.
+  allocateLoadBalancerNodePorts: false
   selector:
     app: qbittorrent
   ports:
@@ -26,9 +38,7 @@ spec:
       protocol: TCP
       port: 30881
       targetPort: 30881
-      nodePort: 30881
     - name: bt-udp
       protocol: UDP
       port: 30881
       targetPort: 30881
-      nodePort: 30881

--- a/argocd/base/qui/deployment.yaml
+++ b/argocd/base/qui/deployment.yaml
@@ -52,13 +52,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
-            - name: media
-              mountPath: /downloads
-              subPath: downloads
+      # Pas de mount media-pvc : qui est un client de l'API qBittorrent, il ne lit
+      # jamais les fichiers. Le monter ajoutait une dependance NFS au demarrage.
       volumes:
         - name: config
           persistentVolumeClaim:
             claimName: qui-pvc
-        - name: media
-          persistentVolumeClaim:
-            claimName: media-pvc


### PR DESCRIPTION
Correctifs sur les deux instances qBittorrent, sur `qui`, et sur la policy d'annonce L2 de Cilium. Aucun changement d'image.

## Le problème de fond

Le port BT tombait **en silence** dès que le pod changeait de node : `type: NodePort` + `externalTrafficPolicy: Local` sans affinity, donc seul le node hébergeant le pod répondait. Le port-forward du routeur pointant vers une IP fixe, tout reschedule (drain, upgrade Talos, OOM) rendait le port injoignable — **le pod reste `Running`, seul le ratio s'effondre, aucune alerte**.

## Les correctifs

### 1. NodePort → LoadBalancer avec IP fixe
Passage en `type: LoadBalancer` avec IP fixe du pool Cilium L2 (`argocd/base/cilium/ip-pool.yaml`). L'IP est stable et indépendante du placement du pod : le port-forward du routeur est configuré une fois pour toutes.

| Service | IP |
|---|---|
| `qbittorrent-bt` | `192.168.1.219` (TCP+UDP 30881) |
| `qbittorrent-seed-bt` | `192.168.1.220` (TCP+UDP 30882) |

### 2. `externalTrafficPolicy: Cluster` + `nodeSelector` sur la policy L2
Une première version de cette PR gardait `Local` pour préserver l'IP source des peers. **Testé en conditions réelles, ça ne fonctionne pas** : l'élection du leader L2 de Cilium 1.17 ne tient pas compte des endpoints du service. Le lease avait été attribué à `kube-master-01`, qui n'héberge aucun pod (`allowSchedulingOnControlPlanes: false`) :

```
$ kubectl get lease -n kube-system | grep l2announce
cilium-l2announce-media-qbittorrent-bt   kube-master-01   27m
$ kubectl get pod -n media -l app=qbittorrent -o wide
qbittorrent-5b889b5bd4-dmcpb   Running   10.244.1.153   kube-worker-01
$ nc -vz 192.168.1.219 30881
nc: connectx to 192.168.1.219 port 30881 (tcp) failed: Connection refused
```

En `Local`, master-01 n'a pas le droit de relayer : le paquet retombe dans sa pile kernel, rien n'écoute sur 30881, le kernel répond RST. Le pod était pourtant sain (`nc` vers `10.244.1.153:30881` → `open`, backend Cilium `active`).

En `Cluster`, n'importe quel node relaie et le placement du pod devient indifférent — le mode de panne disparaît par construction. Contrepartie : SNAT, qBittorrent voit les peers entrants avec l'IP du node relais. Sans effet sur la connectabilité, la vue du tracker ou le ratio ; seules la visibilité des IP de peers et les limites par IP sont affectées.

Ajout en complément d'un `nodeSelector` sur la `CiliumL2AnnouncementPolicy` pour retirer le control-plane des candidats à l'élection, **tous services confondus** : il ne peut servir localement aucun service, l'y laisser n'a aucun intérêt.

### 3. `terminationGracePeriodSeconds: 300`
Le défaut de 30s ne laisse pas le temps d'écrire les `.fastresume` → SIGKILL → **recheck complet du parc au redémarrage**, des heures de hashing sur NFS pendant lesquelles le seeding est à zéro.

### 4. `livenessProbe.failureThreshold: 10`
La WebUI ne répond pas pendant un recheck ou une saturation IO NFS. Le défaut (3 × 30s = 90s) tuait le pod, ce qui relançait un recheck : boucle.

### 5. `fsGroup` aligné sur `PUID`/`PGID` (1000 → 65534)
Le `fsGroup` s'applique aussi à `media-pvc`. Avec `fsGroupChangePolicy: OnRootMismatch`, un gid non aligné peut déclencher un `chgrp -R` du kubelet **sur les 9Ti de l'arbre NFS**.

### 6. `qui` : retrait du mount `media-pvc`
`qui` est un client de l'API qBittorrent, il ne lit jamais les fichiers. Le mount ajoutait une dépendance NFS au démarrage et exposait le pod au point 5.

## Validation

- `yamllint -c .yamllint.yaml` ✅
- `kustomize build` + `kubeconform -strict` sur les bases modifiées ✅
- Attribution des IP `.219`/`.220` vérifiée en cluster, **pas de conflit avec Traefik** ✅
- Chemin applicatif vérifié : `Session\Port=30881`, pod en `LISTEN`, backend Cilium `active` ✅

> `kustomize build argocd/apps/media` complet non exécuté : le générateur KSOPS de `base/plex` n'est pas disponible en local.

## ⚠️ Avant merge

**1. Vérifier les noms d'interfaces des workers.** Le `nodeSelector` retire le control-plane des annonceurs — il faut donc que les 3 workers matchent les regex `interfaces` de la policy (`^eth[0-9]+`, `^eno[0-9]+`, `^ens[0-9]+`). Si leurs NIC s'appellent par exemple `enp1s0`, **plus aucun node ne pourra annoncer** et toutes les IP LoadBalancer tombent, Traefik compris.

**2. Re-élection sur tous les services LB.** Le changement de policy déclenche une ré-élection pour l'ensemble des services, y compris Traefik (lease actuellement sur master-01). Quelques secondes de coupure ingress à prévoir.

**3. Repointer le port-forward du routeur** vers `.219:30881` et `.220:30882`.

**4. Remettre `app-of-apps.yaml` sur `main`** — il pointe actuellement sur cette branche (modif locale non commitée). À faire avant de supprimer la branche, sinon l'ApplicationSet perd sa source et toutes les applications tombent.

## Hors scope

Identifiés mais non traités : factorisation Kustomize des deux bases (`ROADMAP.md:90`), `qbittorrent-exporter` + ServiceMonitor + alerte sur `connection_status`, seeding de la config qBittorrent par ConfigMap, CiliumNetworkPolicy egress, retune des `mountOptions` NFS, securityContext container-level (`TODO.md:17`).