### PR TITLE
feat(media): deployer autobrr pour l'automatisation des annonces IRC

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,6 +69,13 @@
       addLabels: ["major-update"],
     },
     {
+      // autobrr: chaque redemarrage coupe la connexion IRC aux trackers et
+      // fait manquer les annonces le temps de la reconnexion. On choisit le
+      // moment du bump plutot que de le subir en pleine nuit.
+      matchPackageNames: ["ghcr.io/autobrr/autobrr"],
+      automerge: false,
+    },
+    {
       // Renovate utilise `chore(deps):` par defaut, masque par release-please.
       // Les CVE et bumps de securite passent en `fix(deps):` pour apparaitre
       // dans le CHANGELOG sous "Bug Fixes" et trigger un bump patch.

--- a/argocd/apps/media/kustomization.yaml
+++ b/argocd/apps/media/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ../../base/tautulli
   - ../../base/qui
   - ../../base/qbittorrent-seed
+  - ../../base/autobrr

--- a/argocd/base/autobrr/deployment.yaml
+++ b/argocd/base/autobrr/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autobrr
+  namespace: media
+spec:
+  # Une seule instance, imperativement : deux connexions IRC avec le meme nick
+  # provoquent une collision de pseudo cote serveur et sont interpretees comme
+  # un abus par la plupart des trackers prives.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: autobrr
+  template:
+    metadata:
+      labels:
+        app: autobrr
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: autobrr
+          image: ghcr.io/autobrr/autobrr:v1.83.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 7474
+            - name: metrics
+              containerPort: 9094
+          env:
+            - name: TZ
+              value: "Europe/Paris"
+            - name: AUTOBRR__HOST
+              value: "0.0.0.0"
+            - name: AUTOBRR__PORT
+              value: "7474"
+            - name: AUTOBRR__LOG_LEVEL
+              value: "INFO"
+            # Les mises a jour passent par Renovate, pas par l'application.
+            - name: AUTOBRR__CHECK_FOR_UPDATES
+              value: "false"
+            - name: AUTOBRR__METRICS_ENABLED
+              value: "true"
+            - name: AUTOBRR__METRICS_HOST
+              value: "0.0.0.0"
+            - name: AUTOBRR__METRICS_PORT
+              value: "9094"
+          livenessProbe:
+            httpGet:
+              path: /api/healthz/liveness
+              port: 7474
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            # /readiness verifie l'acces a la base, contrairement a /liveness.
+            httpGet:
+              path: /api/healthz/readiness
+              port: 7474
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      # Pas de mount media-pvc : autobrr pousse des .torrent via l'API
+      # qBittorrent, il ne touche jamais aux fichiers. La base SQLite doit par
+      # ailleurs rester sur Longhorn, SQLite sur NFS posant des problemes de
+      # verrouillage pouvant aller jusqu'a la corruption.
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: autobrr-pvc

--- a/argocd/base/autobrr/ingressroute.yaml
+++ b/argocd/base/autobrr/ingressroute.yaml
@@ -1,0 +1,18 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: autobrr
+  namespace: media
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`autobrr.streamixs.com`)
+      kind: Rule
+      middlewares:
+        - name: forward-auth
+          namespace: auth
+      services:
+        - name: autobrr
+          port: 7474
+  tls: {}

--- a/argocd/base/autobrr/kustomization.yaml
+++ b/argocd/base/autobrr/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: media
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingressroute.yaml
+  - servicemonitor.yaml

--- a/argocd/base/autobrr/service.yaml
+++ b/argocd/base/autobrr/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: autobrr
+  namespace: media
+  labels:
+    app: autobrr
+spec:
+  type: ClusterIP
+  selector:
+    app: autobrr
+  ports:
+    - name: http
+      port: 7474
+      targetPort: 7474
+    - name: metrics
+      port: 9094
+      targetPort: 9094

--- a/argocd/base/autobrr/servicemonitor.yaml
+++ b/argocd/base/autobrr/servicemonitor.yaml
@@ -1,0 +1,18 @@
+# serviceMonitorSelectorNilUsesHelmValues: false dans les values de
+# kube-prometheus-stack : Prometheus decouvre tous les ServiceMonitor sans
+# exiger de label de selection.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: autobrr
+  namespace: media
+  labels:
+    app: autobrr
+spec:
+  selector:
+    matchLabels:
+      app: autobrr
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s

--- a/argocd/base/media-pvc/autobrr-pvc.yaml
+++ b/argocd/base/media-pvc/autobrr-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: autobrr-pvc
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn

--- a/argocd/base/media-pvc/kustomization.yaml
+++ b/argocd/base/media-pvc/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - mixarr-pvc.yaml
   - tautulli-pvc.yaml
   - qui-pvc.yaml
+  - autobrr-pvc.yaml


### PR DESCRIPTION
Ajoute **autobrr** à la stack media pour automatiser la récupération des annonces IRC de c411 et générer de l'upload.

## Pourquoi

```
c411 IRC (annonce)  ──►  autobrr  ──►  qbittorrent-seed
    ~1 s                 filtres        API ClusterIP
                                             │
                                             ▼
                                   media-pv / seed-c411/
```

Une annonce IRC arrive en une à deux secondes, là où un flux RSS Prowlarr met plusieurs minutes. Sur un tracker privé, cet écart détermine le rang de seeder — donc l'upload généré. Le chemin est volontairement court : IRC → autobrr → API qBittorrent, sans passer par Prowlarr ni les *arr.

La cible est **`qbittorrent-seed`** et non l'instance principale : c'est sa raison d'être (dossier `seed-c411/`, port BT 30882 dédié). autobrr s'y connecte en ClusterIP, ce qui court-circuite Traefik et `forward-auth` — le middleware ne protège que l'accès humain.

## Contenu

| Fichier | Rôle |
|---|---|
| `base/autobrr/deployment.yaml` | `v1.83.0`, `replicas: 1`, `Recreate` |
| `base/autobrr/service.yaml` | ClusterIP 7474 (UI) + 9094 (métriques) |
| `base/autobrr/ingressroute.yaml` | `autobrr.streamixs.com` + `forward-auth` |
| `base/autobrr/servicemonitor.yaml` | scrape Prometheus 30s |
| `base/media-pvc/autobrr-pvc.yaml` | Longhorn RWO 2Gi (SQLite) |
| `.github/renovate.json5` | exception d'auto-merge |

## Points de conception

### `replicas: 1` est une contrainte, pas une préférence
Deux instances ouvriraient deux connexions IRC sur le même nick : collision de pseudo côté serveur, et comportement assimilé à un abus par la plupart des trackers privés. `Recreate` garantit qu'aucun recouvrement n'a lieu pendant un rollout.

### Pas de mount `media-pvc`
autobrr pousse des `.torrent` via l'API, il ne touche jamais aux fichiers — même cas que `qui`, dont le mount inutile vient d'être retiré en #134. La base SQLite doit par ailleurs impérativement rester sur Longhorn : SQLite sur NFS pose des problèmes de verrouillage pouvant aller jusqu'à la corruption.

### `securityContext` complet dès la création
`runAsNonRoot`, `runAsUser: 65534`, `capabilities.drop: [ALL]`, `allowPrivilegeEscalation: false`, `seccompProfile: RuntimeDefault`. C'est ce que `TODO.md:17` réclame pour les deployments existants — autant ne pas créer une nouvelle dette. `readOnlyRootFilesystem` est volontairement omis : je n'ai pas pu vérifier les chemins d'écriture d'autobrr hors `/config`, c'est un durcissement à ajouter après observation.

### Métriques branchées d'emblée
autobrr expose des métriques Prometheus nativement (`AUTOBRR__METRICS_ENABLED`). Le `serviceMonitorSelectorNilUsesHelmValues: false` de tes values kube-prometheus-stack fait que le ServiceMonitor est découvert sans label dédié.

### Exception Renovate
Chaque redémarrage coupe la connexion IRC et fait manquer les annonces le temps de la reconnexion. Les patches étant en auto-merge la nuit, autobrr est exclu pour que le moment du bump reste choisi.

## Ce que la PR ne peut pas couvrir

**autobrr n'expose aucun session secret en variable d'environnement** — vérifié dans `internal/config/config.go`, le champ n'existe pas dans la struct `Config`. Il n'y a donc **aucun secret SOPS** dans cette PR.

En contrepartie, **tout le sensible réside dans le PVC** : réseaux IRC, mot de passe NickServ, passkey c411, identifiants qBittorrent et filtres se configurent dans l'UI et atterrissent dans la SQLite. C'est le même trou GitOps que la config qBittorrent (cf. #134), et ça fait passer l'item **Velero** du `ROADMAP.md` de confort à seule sauvegarde de la configuration d'automatisation.

## Validation

- `yamllint -c .yamllint.yaml` ✅
- `kustomize build` + `kubeconform -strict` sur `base/autobrr` et `base/media-pvc` ✅
- `renovate.json5` parsé par un vrai parser JSON5 ✅
- Version `v1.83.0`, endpoints `/api/healthz/{liveness,readiness}` et noms de variables `AUTOBRR__*` vérifiés dans le source amont, pas devinés ✅

> `kustomize build argocd/apps/media` complet non exécuté : le générateur KSOPS de `base/plex` n'est pas disponible en local.

## Après le merge

1. Se connecter à `autobrr.streamixs.com`, créer le compte initial.
2. Ajouter `qbittorrent-seed` comme download client : `http://qbittorrent-seed:8080`, avec les identifiants de l'instance (son API renvoie `Forbidden` sans authentification, le bypass localhost étant désactivé).
3. Ajouter le réseau IRC c411 (serveur, port TLS, nick, mot de passe NickServ, commande d'invite).
4. Créer les filtres — **c'est là que se joue le risque principal.**

### ⚠️ Le remplissage disque

C'est ce qui casse la plupart des installations autobrr, bien avant les questions techniques. Un filtre trop large sur un tracker actif peut tirer plusieurs centaines de Go par jour, et quand le NFS sature c'est **toute la stack media** qui tombe, pas seulement le seeding.

Trois garde-fous à mettre en place dès le départ :
- filtres autobrr bornés en taille et en catégorie
- règles de seeding sur `qbittorrent-seed` : limite de ratio, durée max, suppression auto
- alerte Prometheus sur l'espace libre de `media-pv`

### Note pour plus tard

autobrr supporte OIDC nativement (`AUTOBRR__OIDC_*`). Il pourrait donc parler directement à Pocket-ID plutôt que de passer par `forward-auth`. J'ai gardé `forward-auth` pour rester cohérent avec le reste de la stack, mais l'option existe si tu veux du SSO natif avec déconnexion propre.