### PR TITLE
chore(cilium): preparer la montee 1.17 -> 1.20 en paliers

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,6 +69,19 @@
       addLabels: ["major-update"],
     },
     {
+      // Cilium n'autorise QUE les upgrades de minor consecutifs ("the only
+      // tested rollback and upgrade path is between consecutive minor
+      // releases"). Une PR 1.17 -> 1.20 d'un bloc est inapplicable: elle
+      // saute les migrations de CRD intermediaires et casse le CNI.
+      // separateMultipleMinor force une PR par minor (1.18, puis 1.19, puis
+      // 1.20) pour que le chemin d'upgrade reste jouable tel quel.
+      matchDatasources: ["helm"],
+      matchPackageNames: ["cilium"],
+      separateMultipleMinor: true,
+      automerge: false,
+      addLabels: ["cni"],
+    },
+    {
       // autobrr: chaque redemarrage coupe la connexion IRC aux trackers et
       // fait manquer les annonces le temps de la reconnexion. On choisit le
       // moment du bump plutot que de le subir en pleine nuit.

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ CP_NODES      := $(shell yq -r '.nodes[] | select(.controlPlane == true)  | .ipA
 WORKER_NODES  := $(shell yq -r '.nodes[] | select(.controlPlane == false) | .ipAddress' $(TALCONFIG) 2>/dev/null | tr '\n' ',' | sed 's/,$$//')
 FIRST_CP      := $(shell yq -r '[.nodes[] | select(.controlPlane == true)][0].ipAddress' $(TALCONFIG) 2>/dev/null)
 
+# Version Cilium: lue depuis la kustomization qu'ArgoCD applique, jamais
+# dupliquee ici. Un pin en dur finit toujours par diverger et `make cilium`
+# rejoue alors une ancienne version par-dessus celle deployee par ArgoCD.
+CILIUM_KUSTOMIZATION := argocd/apps/cilium/kustomization.yaml
+CILIUM_VERSION       := $(shell yq -r '.helmCharts[] | select(.name == "cilium") | .version' $(CILIUM_KUSTOMIZATION) 2>/dev/null)
+
 # ============================================================
 # Bootstrap complet
 # ============================================================
@@ -67,7 +73,12 @@ endif
 # ============================================================
 
 cilium: ## Installer Cilium via Helm (remplace flannel en dev)
-	@echo "==> Installation de Cilium..."
+ifeq ($(CILIUM_VERSION),)
+	@echo "ERREUR: version Cilium illisible dans $(CILIUM_KUSTOMIZATION)"
+	@echo "        (yq installe ? champ .helmCharts[].version present ?)"
+	@exit 1
+endif
+	@echo "==> Installation de Cilium $(CILIUM_VERSION)..."
 	helm repo add cilium https://helm.cilium.io/ 2>/dev/null || true
 	helm repo update cilium
 ifeq ($(ENV),dev)
@@ -81,7 +92,7 @@ endif
 	helm upgrade --install cilium cilium/cilium \
 		--namespace kube-system \
 		--kubeconfig $(KUBECONFIG) \
-		--version 1.17.1 \
+		--version $(CILIUM_VERSION) \
 		-f argocd/apps/cilium/values.yaml \
 		--wait --timeout 5m
 	@echo "==> Cilium installe. Attente des nodes Ready..."

--- a/argocd/bootstrap/app-of-apps.yaml
+++ b/argocd/bootstrap/app-of-apps.yaml
@@ -6,6 +6,17 @@ metadata:
   labels:
     env: dev
 spec:
+  # Sans ceci, l'ApplicationSet reecrit le spec des Applications qu'il genere
+  # et un passage en sync manuelle est annule en quelques secondes.
+  # Cilium est le CNI: un upgrade traverse plusieurs minors consecutifs et
+  # chaque palier fait rouler le DaemonSet sur les 4 noeuds. On veut declencher
+  # ces paliers un par un, pas les subir au merge. La derogation ne porte que
+  # sur /spec/syncPolicy/automated: tout le reste du spec reste pilote par le
+  # template ci-dessous.
+  ignoreApplicationDifferences:
+    - name: cilium
+      jsonPointers:
+        - /spec/syncPolicy/automated
   generators:
     - git:
         repoURL: https://github.com/streamixs/cluster


### PR DESCRIPTION
## Contexte

Cilium tourne en **1.17.1** sur un cluster **k8s 1.35.3**. La matrice de support de Cilium 1.17 s'arrête à k8s 1.32 : on est **3 minors hors support**. Seul Cilium 1.20 couvre 1.35 (matrice 1.33→1.36).

Cilium n'autorise que les sauts de minor consécutifs :

> The only tested rollback and upgrade path is between consecutive minor releases.

Le chemin est donc **1.17 → 1.18 → 1.19 → 1.20**, en trois PRs distinctes qui suivront.

**Cette PR ne change aucune version.** Elle pose seulement les garde-fous.

## Contenu

### `Makefile` — supprimer le pin en dur
La cible `cilium` épinglait `--version 1.17.1`, en doublon de `argocd/apps/cilium/kustomization.yaml`. Pendant l'opération, un `make cilium` par réflexe aurait **downgradé le CNI** par-dessus la version déployée par ArgoCD. La version est maintenant dérivée de la kustomization via `yq`, avec un garde qui échoue proprement si elle est illisible.

### `.github/renovate.json5` — une PR par minor
`separateMultipleMinor: true` sur cilium. La PR #120 propose `1.17.1 → 1.20.0` d'un bloc : elle saute les migrations de CRD intermédiaires et rendrait le CNI inapplicable. **PR #120 à fermer** au profit de la séquence en paliers.

### `argocd/bootstrap/app-of-apps.yaml` — permettre la sync manuelle
Sans `ignoreApplicationDifferences`, l'ApplicationSet réécrit le spec des Applications qu'il génère et annule tout passage en sync manuelle en quelques secondes. La dérogation ne porte que sur `/spec/syncPolicy/automated`, et uniquement pour `cilium`.

Nécessaire parce qu'ArgoCD est en `automated` + `selfHeal` + `prune` : sans ça, chaque merge ferait rouler le DaemonSet CNI sur les 4 nœuds sans fenêtre choisie.

> ℹ️ L'ApplicationSet n'est ni dans Terraform ni géré par ArgoCD (appliqué via `kubectl apply` au bootstrap). Il faudra un `kubectl apply -f argocd/bootstrap/app-of-apps.yaml` après merge.

## Ce que l'audit du cluster a écarté

- **0 CiliumNetworkPolicy / CiliumClusterwideNetworkPolicy** → élimine les 3 plus gros pièges des notes d'upgrade (règles Kafka retirées en 1.20, `FromRequires`/`ToRequires` interdits en 1.19, extensions Go Envoy `l7`/`l7proto` en 1.20)
- **0 CiliumNodeConfig** → la migration v2alpha1→v2 de 1.20 est un no-op
- **Kernel 6.18.18** → très au-dessus du minimum 5.10 exigé par 1.18+
- **`CiliumL2AnnouncementPolicy` reste en `v2alpha1`** en 1.20 (vérifié dans la doc) → `l2-policy.yaml` ne bouge pas

## Suite

| Palier | Contenu |
|---|---|
| P1 | `version: 1.18.12` — puis vérifier que `cilium.io/v2` apparaît sur le CRD pool |
| P2 | `ip-pool.yaml` → `cilium.io/v2` (impossible avant 1.18 : seul `v2alpha1` est servi aujourd'hui) |
| P3 | `version: 1.19.6` + retrait de `externalIPs` des values (flag `--enable-external-ips` supprimé) |
| P4 | `version: 1.20.0` |

Point de vigilance sur tout le parcours : `enable-l2-neigh-discovery` passe de `true` à `false` en 1.18. Rollback immédiat si les IP LoadBalancer (`traefik` .210, `qbittorrent-bt` .219, `qbittorrent-seed-bt` .220) deviennent instables : `l2NeighDiscovery.enabled: true` dans les values.