### PR TITLE
feat(cilium): palier 1 - passer de 1.17.1 a 1.18.12

### DIFF
--- a/argocd/apps/cilium/kustomization.yaml
+++ b/argocd/apps/cilium/kustomization.yaml
@@ -12,4 +12,4 @@ helmCharts:
     releaseName: cilium
     repo: https://helm.cilium.io/
     valuesFile: values.yaml
-    version: 1.17.1
+    version: 1.18.12


### PR DESCRIPTION
Premier des trois paliers vers Cilium 1.20. Suite de #142.

## Pourquoi en paliers

Cilium n'autorise que les sauts de minor consécutifs :

> The only tested rollback and upgrade path is between consecutive minor releases.

Donc **1.17 → 1.18 → 1.19 → 1.20**, jamais d'un bloc.

## Ce que change ce palier

Diff réel de `cilium-config`, rendu via `kustomize build --enable-helm` sur les deux versions :

| | Nombre | Détail |
|---|---|---|
| Clés supprimées | 8 | Flags dépréciés, **aucun défini dans nos values** |
| Clés ajoutées | 11 | Nouveaux défauts amont |
| **Valeurs modifiées** | **1** | `enable-l2-neigh-discovery: true → false` |

Supprimées : `arping-refresh-period`, `enable-experimental-lb`, `enable-k8s-terminating-endpoint`, `enable-local-redirect-policy`, `enable-runtime-device-detection`, `hubble-export-file-max-backups`, `hubble-export-file-max-size-mb`, `ipam-multi-pool-pre-allocation`.

`ipam=kubernetes` est **inchangé**.

### Le seul point de vigilance

`enable-l2-neigh-discovery` passe à `false`. J'ai envisagé de le pinner à `true` pour faire de ce palier un bump d'image pur, mais ça figerait un défaut que l'amont a changé volontairement (le kernel résout le voisinage via les managed-neighbors). Le cluster est en **tunnel vxlan**, l'impact attendu est nul.

**Rollback si les IP LoadBalancer deviennent instables** — `l2NeighDiscovery.enabled: true` dans `values.yaml`.

IP à surveiller : `traefik` .210, `qbittorrent-bt` .219, `qbittorrent-seed-bt` .220.

## Images

```
cilium           v1.17.1 -> v1.18.12
operator-generic v1.17.1 -> v1.18.12
hubble-relay     v1.17.1 -> v1.18.12
hubble-ui        v0.13.1 -> v0.13.5
cilium-envoy     v1.31.5 -> v1.36.9
```

## Déroulé

L'app `cilium` est en **sync manuelle** depuis #142 — ce merge ne déclenche donc **rien** tout seul. Le rolling du DaemonSet sera déclenché explicitement, puis vérifié :

1. `Cluster health 4/4`, agents `Ready`
2. `KubeProxyReplacement: True`
3. Les 3 IP LoadBalancer répondent toujours
4. **`cilium.io/v2` apparaît bien sur le CRD `ciliumloadbalancerippools`** — condition d'entrée du palier suivant

## Après ce palier

- Supprimer le CRD `ciliumexternalworkloads` (0 ressource). Feature retirée en 1.18, mais l'operator 1.17 la réenregistre : la suppression est inopérante avant ce bump.
- Puis migrer `ip-pool.yaml` vers `cilium.io/v2`, impossible tant que seul `v2alpha1` est servi.

`values.yaml` ne bouge pas dans cette PR.