### PR TITLE
chore(cilium): migrer CiliumLoadBalancerIPPool vers cilium.io/v2

### DIFF
--- a/argocd/base/cilium/ip-pool.yaml
+++ b/argocd/base/cilium/ip-pool.yaml
@@ -1,4 +1,6 @@
-apiVersion: cilium.io/v2alpha1
+# v2alpha1 est retire en 1.19. Cilium ne sert cette ressource en v2 qu'a
+# partir de 1.18, donc cette bascule ne peut pas preceder ce palier.
+apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: default-pool


### PR DESCRIPTION
Étape intercalaire entre le palier **1.18** (#143) et le palier **1.19**. Ce n'est pas un bump de version.

## Pourquoi maintenant, et pas avant ni après

`v2alpha1` est **retiré en 1.19**. Mais Cilium n'expose `CiliumLoadBalancerIPPool` en `v2` **qu'à partir de 1.18**. Vérifié sur le cluster :

```
$ kubectl get crd ciliumloadbalancerippools.cilium.io \
    -o jsonpath='{range .spec.versions[*]}{.name}...'
v2alpha1(served=true,storage=true)     # <- v2 absent en 1.17.1
```

La fenêtre est donc étroite :

| Moment | Possible ? |
|---|---|
| Avant #143 (sur 1.17.1) | ❌ `v2` n'existe pas, ArgoCD partirait en erreur |
| **Après #143 (sur 1.18.12)** | ✅ les deux versions sont servies |
| Après le palier 1.19 | ❌ trop tard, `v2alpha1` est déjà retiré |

> ⚠️ **Ne pas merger avant que #143 soit synchronisé et vérifié sur le cluster.** La CI ne peut pas attraper cette contrainte : `kubeconform` tourne avec `-ignore-missing-schemas` sur les CRD, le rendu passera au vert quoi qu'il arrive.

## Impact sur les IP allouées

Aucun. ArgoCD suit les ressources par **GroupKind**, pas par version : le groupe reste `cilium.io` et le pool est mis à jour en place plutôt que recréé. Les IP déjà allouées ne sont pas relâchées :

- `traefik` → 192.168.1.210
- `qbittorrent-bt` → 192.168.1.219
- `qbittorrent-seed-bt` → 192.168.1.220

## Hors périmètre

`CiliumL2AnnouncementPolicy` **reste en `v2alpha1`** — c'est toujours l'unique version servie en 1.20 (vérifié dans la doc amont). `l2-policy.yaml` ne bouge pas.