### PR TITLE
feat(cilium): palier 2 - passer de 1.18.12 a 1.19.6

### DIFF
--- a/argocd/apps/cilium/kustomization.yaml
+++ b/argocd/apps/cilium/kustomization.yaml
@@ -12,4 +12,4 @@ helmCharts:
     releaseName: cilium
     repo: https://helm.cilium.io/
     valuesFile: values.yaml
-    version: 1.18.12
+    version: 1.19.6

--- a/argocd/apps/cilium/values.yaml
+++ b/argocd/apps/cilium/values.yaml
@@ -37,9 +37,6 @@ devices:
 l2announcements:
   enabled: true
 
-externalIPs:
-  enabled: true
-
 hubble:
   relay:
     enabled: true


### PR DESCRIPTION
Deuxième des trois paliers vers Cilium 1.20. Suite de #143.

> ⛔ **Ne pas merger avant #144.** `v2alpha1` n'est plus servi à partir de 1.19 : si `ip-pool.yaml` est encore en `v2alpha1` au moment de la sync, le pool devient inapplicable et les IP LoadBalancer tombent.

## Diff de `cilium-config`

Rendu **contre le 1.18.12 réellement déployé**, pas contre le repo.

| | Nombre |
|---|---|
| Clés supprimées | 2 |
| Clés ajoutées | 11, toutes inertes par défaut |
| Valeurs modifiées | 3 |

**Supprimées** : `enable-internal-traffic-policy`, `enable-svc-source-range-check` — devenues inconditionnelles côté amont.

**Ajoutées, valeurs vérifiées** : `enable-host-firewall=false`, `enable-service-topology=false`, `policy-deny-response=none`, `packetization-layer-pmtud-mode=blackhole`, `enable-no-service-endpoints-routable=true`, plus les clés ClusterMesh et proxy.

**Modifiées** :

```
mesh-auth-enabled                true  -> false
policy-default-local-cluster     false -> true
unmanaged-pod-watcher-interval   15    -> 15s
```

`policy-default-local-cluster` est le changement cassant annoncé par l'upstream : les sélecteurs de network policy ne portent plus que sur le cluster local. **Sans ClusterMesh et avec 0 CiliumNetworkPolicy sur le cluster, l'impact est nul.**

## Retrait de `externalIPs` des values

Le flag `--enable-external-ips` est supprimé en 1.19, absorbé par `kubeProxyReplacement`.

Vérifié : `enable-external-ips` est **déjà absent** du `cilium-config` rendu en 1.18. Notre `externalIPs.enabled: true` était donc déjà ignoré en silence. Ce retrait **ne modifie pas le rendu** — c'est du nettoyage, pas un changement de comportement.

## Images

```
cilium           v1.18.12 -> v1.19.6
operator-generic v1.18.12 -> v1.19.6
hubble-relay     v1.18.12 -> v1.19.6
cilium-envoy     inchangé (même digest qu'en 1.18)
hubble-ui        inchangé (v0.13.5)
```

Les images seront pré-chargées sur les 4 nœuds via `talosctl image pull` avant la sync, comme pour #143 — le palier 1.18 s'est déroulé sans un seul pull réseau et sans aucun restart.

## Vérification après sync

`Synced` **n'est pas** un signal exploitable : l'app reste `OutOfSync` en permanence à cause de deux dérives pré-existantes (clés fantômes figées par le field-manager `helm` du bootstrap, et certificats Hubble régénérés aléatoirement à chaque rendu). Les deux seront traitées dans une PR dédiée après le palier 1.20.

La vérification se fait donc par inspection directe : version de l'agent, `Cluster health`, `KubeProxyReplacement`, et les 3 IP LoadBalancer (`.210`, `.219`, `.220`).