### PR TITLE
feat(cilium): palier 3 - passer de 1.19.6 a 1.20.1

### DIFF
--- a/argocd/apps/cilium/kustomization.yaml
+++ b/argocd/apps/cilium/kustomization.yaml
@@ -12,4 +12,4 @@ helmCharts:
     releaseName: cilium
     repo: https://helm.cilium.io/
     valuesFile: values.yaml
-    version: 1.19.6
+    version: 1.20.0

--- a/argocd/apps/cilium/kustomization.yaml
+++ b/argocd/apps/cilium/kustomization.yaml
@@ -12,4 +12,4 @@ helmCharts:
     releaseName: cilium
     repo: https://helm.cilium.io/
     valuesFile: values.yaml
-    version: 1.20.0
+    version: 1.20.1


### PR DESCRIPTION
Dernier palier. Suite de #143 → #144 → #146.

**C'est celui qui règle le problème de fond** : Cilium 1.20 est la seule version dont la matrice de support couvre **k8s 1.35** (1.33 → 1.36). Le cluster tournait 3 minors hors support depuis la montée en 1.35.3.

> 📌 Cette PR ciblait initialement **1.20.0**. Elle vise désormais **1.20.1**, sortie entre-temps. Le diff de `cilium-config` entre 1.20.0 et 1.20.1 est **vide** — patch pur, et toujours un seul saut de minor depuis 1.19.6.

## Diff de `cilium-config`

Rendu contre le **1.19.6 réellement déployé**.

| | Nombre |
|---|---|
| Clés supprimées | **0** |
| Valeurs modifiées | **0** |
| Clés ajoutées | 8, toutes inertes |

```
enable-datapath-plugins=false
enable-dynamic-source-lookup-nodeport=false
envoy-node-locality-enabled=false
envoy-xds-mode=ads
envoy-access-log-enabled=true
proxy-cluster-max-pending-requests=1024
datapath-plugins-state-dir=/var/run/cilium/plugins
clustermesh-default-global-namespace=true
```

Le plus doux des trois paliers : aucun changement de comportement, uniquement de nouvelles fonctionnalités désactivées par défaut.

## Prérequis 1.20, vérifiés sur le cluster

| Exigence amont | État |
|---|---|
| `CiliumNodeConfig` `v2alpha1` → `v2` | **0 ressource** → no-op |
| Règles `kafka` / `l7` / `l7proto` interdites | **0 network policy** |
| Gateway API ≥ v1.6.1, `TLSRoute` `v1alpha2` → `v1` | **sans objet** |

Sur le dernier point : Cilium n'active pas Gateway API (aucune clé `enable-gateway-api` dans le rendu) et le CRD `tlsroutes` — celui visé par la migration — **n'existe pas** sur le cluster. Les 6 CRDs Gateway API présents (`gateways`, `httproutes`, `grpcroutes`, `gatewayclasses`, `referencegrants`, `backendtlspolicies`) sont hors périmètre Cilium.

## Images

```
cilium           v1.19.6 -> v1.20.1
operator-generic v1.19.6 -> v1.20.1
hubble-relay     v1.19.6 -> v1.20.1
cilium-envoy     v1.36.9 -> v1.37.5   (build 766ccfb37260)
hubble-ui        inchangé (v0.13.5)
```

⚠️ `cilium-envoy` reste en `v1.37.5` entre 1.20.0 et 1.20.1 mais **change de build** (`766ccfb37260` au lieu de `7cffc778c923`) — donc nouveau digest. Les images pré-chargées pour 1.20.0 étaient périmées, le pré-chargement a été refait.

Pré-chargées sur les 4 nœuds avant la sync. Les paliers 1.18 et 1.19 se sont déroulés sans un seul pull réseau et **sans aucun restart**.

## Après ce palier

Une PR dédiée pour les deux dérives pré-existantes, sans lien avec l'upgrade :

- **Certificats Hubble** régénérés aléatoirement à chaque rendu → `hubble.tls.auto.method: certmanager`
- **Clés fantômes** figées par le field-manager `helm` du bootstrap → retrait du bookkeeping Helm orphelin

Tant qu'elles sont là, l'app reste `OutOfSync` en permanence — d'où la vérification par inspection directe à chaque palier plutôt que par le statut ArgoCD.