### PR TITLE
fix(deps): epingler argo-rollouts et couvrir les dependances non suivies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,44 @@
       matchPackageNames: ["lscr.io/linuxserver/**"],
       groupName: "linuxserver images",
     },
+    // --- Schemas de versioning ----------------------------------------
+    // Ces images etaient bien DETECTEES par Renovate (elles figurent au
+    // Dependency Dashboard) mais aucune update n'etait jamais proposee: le
+    // versioning docker par defaut n'ordonne pas leurs tags. Resultat, les 7
+    // ont accumule du retard en silence. Un tag non ordonnable est pire
+    // qu'une dependance absente: le dashboard donne l'illusion du suivi.
+    {
+      // Plex: `X.Y.Z.BUILD-<hash git>`. Le suffixe est traite comme un
+      // pre-release a comparer litteralement, or `-1e34174b1` et
+      // `-cb3ebc72d` ne sont pas ordonnables. On compare sur les 4
+      // composantes numeriques, le hash est matche mais non capture.
+      matchDatasources: ["docker"],
+      matchPackageNames: ["plexinc/pms-docker"],
+      versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)-\\w+$",
+    },
+    {
+      // linuxserver, format majoritaire `X.Y.Z.BUILD-lsN`.
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "lscr.io/linuxserver/sonarr",
+        "lscr.io/linuxserver/radarr",
+        "lscr.io/linuxserver/lidarr",
+        "lscr.io/linuxserver/prowlarr",
+      ],
+      versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)-ls(?<revision>\\d+)$",
+    },
+    {
+      // qbittorrent: `X.Y.Z-rN-lsN`, le -rN etant le rebuild amont.
+      matchDatasources: ["docker"],
+      matchPackageNames: ["lscr.io/linuxserver/qbittorrent"],
+      versioning: "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-r(?<build>\\d+)-ls(?<revision>\\d+)$",
+    },
+    {
+      // tautulli: prefixe `v` et 3 composantes seulement.
+      matchDatasources: ["docker"],
+      matchPackageNames: ["lscr.io/linuxserver/tautulli"],
+      versioning: "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ls(?<revision>\\d+)$",
+    },
     {
       matchManagers: ["github-actions"],
       groupName: "github-actions",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -89,12 +89,14 @@
       automerge: false,
     },
     {
-      // Renovate utilise `chore(deps):` par defaut, masque par release-please.
-      // Les CVE et bumps de securite passent en `fix(deps):` pour apparaitre
-      // dans le CHANGELOG sous "Bug Fixes" et trigger un bump patch.
+      // `chore` est marque hidden dans release-please-config.json: un
+      // `chore(deps):` ne bumpe rien et n'apparait pas au CHANGELOG, donc la
+      // version restait figee quoi qu'on merge. En emettant `fix(deps):`,
+      // chaque update merge donne un bump patch (0.6.0 -> 0.6.1) et une
+      // ligne de CHANGELOG sous "Bug Fixes".
       matchDepTypes: ["dependencies"],
       matchPackageNames: ["*"],
-      semanticCommitType: "chore",
+      semanticCommitType: "fix",
     },
   ],
 
@@ -121,6 +123,37 @@
       matchStrings: [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+tag:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
       ],
+    },
+    {
+      // Image annotee dans un values Helm hors argocd/base (le manager
+      // kubernetes est scope a argocd/base/**, il ne voit pas terraform/).
+      // Cible actuelle: viaductoss/ksops, init container du repoServer ArgoCD.
+      customType: "regex",
+      managerFilePatterns: ["/(^|/)[a-z0-9-]*values\\.ya?ml$/"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+image:\\s*\\S+:(?<currentValue>[^\"'\\s@]+)",
+      ],
+    },
+    {
+      // Version epinglee dans une variable Terraform. Le manager terraform
+      // ne lit que les providers et modules, pas une version de chart passee
+      // en variable. Cible actuelle: le chart Helm d'ArgoCD lui-meme, qui
+      // n'etait suivi par rien alors qu'il gere tout le reste.
+      customType: "regex",
+      managerFilePatterns: ["/^terraform/.+\\.tf$/"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)( registryUrl=(?<registryUrl>\\S+))?\\s+default\\s*=\\s*\"(?<currentValue>[^\"]+)\"",
+      ],
+    },
+    {
+      // Manifest distant epingle sur une release GitHub, tire par kustomize.
+      // Generique: couvre argo-rollouts et tout futur manifest du meme type.
+      customType: "regex",
+      managerFilePatterns: ["/(^|/)kustomization\\.ya?ml$/"],
+      matchStrings: [
+        "https://github\\.com/(?<depName>[^/\\s]+/[^/\\s]+)/releases/download/(?<currentValue>[^/\\s]+)/",
+      ],
+      datasourceTemplate: "github-releases",
     },
   ],
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ talos/*/clusterconfig/
 # Helm charts cached locally by `kustomize build --enable-helm`
 argocd/**/charts/
 
+
+# Worktrees git crees par Claude Code — depots imbriques, jamais a committer
+.claude/worktrees/

--- a/argocd/apps/argo-rollouts/kustomization.yaml
+++ b/argocd/apps/argo-rollouts/kustomization.yaml
@@ -1,5 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# Version epinglee, jamais `latest`: avec latest, ArgoCD installe ce qui est
+# publie a l'instant du rendu. Le manifeste ne decrit plus ce qui tourne, deux
+# syncs a deux dates donnent deux versions, et rien n'apparait dans Git.
+# Renovate suit cette URL via le custom manager github-releases.
 resources:
-  - https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+  - https://github.com/argoproj/argo-rollouts/releases/download/v1.9.1/install.yaml

--- a/terraform/resources/argocd/argocd-values.yaml
+++ b/terraform/resources/argocd/argocd-values.yaml
@@ -24,6 +24,7 @@ repoServer:
 
   initContainers:
     - name: install-ksops
+      # renovate: datasource=docker depName=viaductoss/ksops
       image: viaductoss/ksops:v4.3.3
       command: ["/bin/sh", "-c"]
       args:

--- a/terraform/resources/argocd/variables.tf
+++ b/terraform/resources/argocd/variables.tf
@@ -7,7 +7,8 @@ variable "namespace" {
 variable "chart_version" {
   description = "Argo CD Helm chart version"
   type        = string
-  default     = "9.4.12"
+  # renovate: datasource=helm depName=argo-cd registryUrl=https://argoproj.github.io/argo-helm
+  default = "9.4.12"
 }
 
 variable "values_file" {


### PR DESCRIPTION
Passe d'audit sur la couverture Renovate, à partir du [Dependency Dashboard](../issues/91) — la seule source qui fasse autorité sur ce que Renovate voit réellement.

**33 dépendances étaient déjà suivies.** Trois ne l'étaient pas.

## 1. `argo-rollouts` tirait `latest` ⚠️

```diff
- .../releases/latest/download/install.yaml
+ .../releases/download/v1.9.1/install.yaml
```

**Ce n'était pas qu'un bump manqué, mais une rupture de reproductibilité.** ArgoCD installait ce qui était publié *à l'instant du rendu* : le manifeste ne décrivait pas ce qui tourne, deux syncs à deux dates donnaient deux versions, et rien n'apparaissait dans Git.

`v1.9.1` est la dernière stable **et** déjà la version déployée → **le rendu est inchangé** (vérifié : 15 ressources, image `argo-rollouts:v1.9.1`).

## 2. Le chart Helm d'ArgoCD n'était suivi par rien

`9.4.12`, dans `terraform/resources/argocd/variables.tf`. Le manager `terraform` lit les providers et les modules, pas une version de chart passée en variable.

ArgoCD gérait tout le reste **sans être géré lui-même**.

## 3. `viaductoss/ksops` échappait au manager `kubernetes`

Init container du repoServer ArgoCD, dans `terraform/` — hors du scope `argocd/base/**`.

## Les trois custom managers ajoutés

Regex **validées contre les fichiers réels**, pas seulement écrites :

| Manager | Cible | Match obtenu |
|---|---|---|
| image annotée hors `argocd/base` | `argocd-values.yaml` | `viaductoss/ksops` → `v4.3.3` |
| version annotée en variable Terraform | `variables.tf` | `argo-cd` → `9.4.12` |
| manifest distant sur release GitHub | `kustomization.yaml` | `argoproj/argo-rollouts` → `v1.9.1` |

Le troisième est **générique** : il couvrira tout futur manifeste distant du même type, pas seulement argo-rollouts.

Vérifié aussi que l'annotation immich existante **matche toujours** (`ghcr.io/immich-app/immich-server` → `v3.1.0`) — pas de régression.

## Versioning : la version va enfin bouger

```diff
- semanticCommitType: "chore",
+ semanticCommitType: "fix",
```

`chore` est marqué `hidden: true` dans `release-please-config.json` : **aucune update de dépendance ne bumpait la version ni n'apparaissait au CHANGELOG.** Chaque update mergée donnera maintenant un bump patch — `0.6.0` → `0.6.1` — sous « Bug Fixes ».

Cette PR étant elle-même un `fix:`, elle sert de test de bout en bout du mécanisme.

## Écarté après vérification

**`immich-machine-learning` semblait non suivi — il ne l'est pas.** Il ne déclare qu'un `repository:` et hérite du `tag:` global en tête de `values.yaml`, lui-même annoté. Le déployé le confirme : `server` et `machine-learning` sont tous deux en `v3.1.0`. Lui ajouter un tag dédié créerait un second endroit à bumper, donc de la dérive garantie.

**`thomseddon/traefik-forward-auth`** reste sur le tag flottant `2`, par choix explicite.

## Hors périmètre, signalé

`terraform/resources/argocd/main.tf` ne passe pas `terraform fmt -check`. **Dérive pré-existante**, ce fichier n'est pas touché par cette PR. `terraform validate` passe (`Success! The configuration is valid.`).